### PR TITLE
Fix double-escaping of , and ; in compound properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 matrix:
   allow_failures:
-    php: 5.5.10
+    - php: 5.5.10
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ php:
 matrix:
   allow_failures:
     - php:
-        5.5.10
-        5.6
+      - 5.5.10
+      - 5.6
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 5.6
 
 matrix:
-    allowed_failures:
+    allow_failures:
         php: 5.5.10
 
 script: phpunit --configuration tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ php:
 
 matrix:
   allow_failures:
-    - php: 5.5.10
+    - php:
+        5.5.10
+        5.6
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
   - 5.6
 
 matrix:
-    allow_failures:
-        php: 5.5.10
+  allow_failures:
+    php: 5.5.10
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.5.9
+  - 5.5.10
+  - 5.6
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 5.5.10
   - 5.6
 
+matrix:
+    allowed_failures:
+        php: 5.5.10
+
 script: phpunit --configuration tests/phpunit.xml
 
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ php:
 
 matrix:
   allow_failures:
-    - php:
-      - 5.5.10
-      - 5.6
+    - php: 5.5.10
+    - php: 5.6
 
 script: phpunit --configuration tests/phpunit.xml
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2.1.4-stable (????-??-??)
+	* Fixed: Issue #87: Several compatibility fixes related to timezone
+	  handling changes in PHP 5.5.10.
+
 2.1.3-stable (2013-10-02)
 	* Fixed: Issue #55. \r must be stripped from property values.
 	* Fixed: Issue #65. Putting quotes around parameter values that contain a

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2.1.4-stable (????-??-??)
+2.1.4-stable (2014-03-30)
 	* Fixed: Issue #87: Several compatibility fixes related to timezone
 	  handling changes in PHP 5.5.10.
 

--- a/lib/Sabre/VObject/Parameter.php
+++ b/lib/Sabre/VObject/Parameter.php
@@ -72,21 +72,19 @@ class Parameter extends Node {
         $src = array(
             '\\',
             "\n",
-            ';',
-            ',',
         );
         $out = array(
             '\\\\',
             '\n',
-            '\;',
-            '\,',
         );
 
-        $value = str_replace($src, $out, $this->value);
-        if (strpos($value,":")!==false) {
-            $value = '"' . $value . '"';
+        // quote parameters according to RFC 5545, Section 3.2
+        $quotes = '';
+        if (preg_match('/[:;,]/', $this->value)) {
+            $quotes = '"';
         }
-        return $this->name . '=' . $value;
+
+        return $this->name . '=' . $quotes . str_replace($src, $out, $this->value) . $quotes;
 
     }
 

--- a/lib/Sabre/VObject/Property.php
+++ b/lib/Sabre/VObject/Property.php
@@ -195,6 +195,15 @@ class Property extends Node {
             '\n',
             '',
         );
+
+        // avoid double-escaping of \, and \; from Compound properties
+        if (method_exists($this, 'setParts')) {
+            $src[] = '\\\\,';
+            $out[] = '\\,';
+            $src[] = '\\\\;';
+            $out[] = '\\;';
+        }
+
         $str.=':' . str_replace($src, $out, $this->value);
 
         $out = '';

--- a/lib/Sabre/VObject/TimeZoneUtil.php
+++ b/lib/Sabre/VObject/TimeZoneUtil.php
@@ -408,9 +408,21 @@ class TimeZoneUtil {
     static public function getTimeZone($tzid, Component $vcalendar = null, $failIfUncertain = false) {
 
         // First we will just see if the tzid is a support timezone identifier.
-        try {
-            return new \DateTimeZone($tzid);
-        } catch (\Exception $e) {
+        //
+        // The only exception is if the timezone starts with (. This is to
+        // handle cases where certain microsoft products generate timezone
+        // identifiers that for instance look like:
+        //
+        // (GMT+01.00) Sarajevo/Warsaw/Zagreb
+        //
+        // Since PHP 5.5.10, the first bit will be used as the timezone and
+        // this method will return just GMT+01:00. This is wrong, because it
+        // doesn't take DST into account.
+        if ($tzid[0]!=='(') {
+            try {
+                return new \DateTimeZone($tzid);
+            } catch (\Exception $e) {
+            }
         }
 
         // Next, we check if the tzid is somewhere in our tzid map.

--- a/lib/Sabre/VObject/TimeZoneUtil.php
+++ b/lib/Sabre/VObject/TimeZoneUtil.php
@@ -420,6 +420,12 @@ class TimeZoneUtil {
 
         // Maybe the author was hyper-lazy and just included an offset. We
         // support it, but we aren't happy about it.
+        //
+        // Note that the path in the source will never be taken from PHP 5.5.10
+        // onwards. PHP 5.5.10 supports the "GMT+0100" style of format, so it
+        // already gets returned early in this function. Once we drop support
+        // for versions under PHP 5.5.10, this bit can be taken out of the
+        // source.
         if (preg_match('/^GMT(\+|-)([0-9]{4})$/', $tzid, $matches)) {
             return new \DateTimeZone('Etc/GMT' . $matches[1] . ltrim(substr($matches[2],0,2),'0'));
         }

--- a/lib/Sabre/VObject/TimeZoneUtil.php
+++ b/lib/Sabre/VObject/TimeZoneUtil.php
@@ -298,6 +298,36 @@ class TimeZoneUtil {
         'Fiji'                   => 'Pacific/Fiji',
         'New Zealand'            => 'Pacific/Auckland',
         'Tonga'                  => 'Pacific/Tongatapu',
+
+        // PHP 5.5.10 failed on a few timezones that were valid before. We're
+        // normalizing them here.
+        'CST6CDT'   => 'America/Chicago',
+        'Cuba'      => 'America/Havana',
+        'Egypt'     => 'Africa/Cairo',
+        'Eire'      => 'Europe/Dublin',
+        'EST5EDT'   => 'America/New_York',
+        'Factory'   => 'UTC',
+        'GB-Eire'   => 'Europe/London',
+        'GMT0'      => 'UTC',
+        'Greenwich' => 'UTC',
+        'Hongkong'  => 'Asia/Hong_Kong',
+        'Iceland'   => 'Atlantic/Reykjavik',
+        'Iran'      => 'Asia/Tehran',
+        'Israel'    => 'Asia/Jerusalem',
+        'Jamaica'   => 'America/Jamaica',
+        'Japan'     => 'Asia/Tokyo',
+        'Kwajalein' => 'Pacific/Kwajalein',
+        'Libya'     => 'Africa/Tripoli',
+        'MST7MDT'   => 'America/Denver',
+        'Navajo'    => 'America/Denver',
+        'NZ-CHAT'   => 'Pacific/Chatham',
+        'Poland'    => 'Europe/Warsaw',
+        'Portugal'  => 'Europe/Lisbon',
+        'PST8PDT'   => 'America/Los_Angeles',
+        'Singapore' => 'Asia/Singapore',
+        'Turkey'    => 'Europe/Istanbul',
+        'Universal' => 'UTC',
+        'W-SU'      => 'Europe/Moscow',
     );
 
     /**
@@ -461,10 +491,7 @@ class TimeZoneUtil {
                             $lic = substr($lic,8);
                         }
 
-                        try {
-                            return new \DateTimeZone($lic);
-                        } catch (\Exception $e) {
-                        }
+                        return self::getTimeZone($lic, null, $failIfUncertain);
 
                     }
                     // Microsoft may add a magic number, which we also have an

--- a/lib/Sabre/VObject/Version.php
+++ b/lib/Sabre/VObject/Version.php
@@ -14,7 +14,7 @@ class Version {
     /**
      * Full version number
      */
-    const VERSION = '2.1.3';
+    const VERSION = '2.1.4';
 
     /**
      * Stability : alpha, beta, stable

--- a/tests/Sabre/VObject/ParameterTest.php
+++ b/tests/Sabre/VObject/ParameterTest.php
@@ -48,7 +48,7 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('CN="colon, with"',$param->serialize());
 
         $param = new Parameter('cn','semicolon; too');
-        $this->assertEquals('NC="semicolon; too"',$param->serialize());
+        $this->assertEquals('CN="semicolon; too"',$param->serialize());
 
     }
 }

--- a/tests/Sabre/VObject/ParameterTest.php
+++ b/tests/Sabre/VObject/ParameterTest.php
@@ -41,4 +41,14 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('NAME="va:lue"',$param->serialize());
 
     }
+
+    function testSerializeQuoted() {
+
+        $param = new Parameter('cn','colon, with');
+        $this->assertEquals('CN="colon, with"',$param->serialize());
+
+        $param = new Parameter('cn','semicolon; too');
+        $this->assertEquals('NC="semicolon; too"',$param->serialize());
+
+    }
 }

--- a/tests/Sabre/VObject/Property/CompoundTest.php
+++ b/tests/Sabre/VObject/Property/CompoundTest.php
@@ -56,4 +56,19 @@ class CompoundTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, count($elem->getParts()));
 
     }
+
+    function testSerialize() {
+
+        $arr = array(
+            'ABC, Inc.',
+            'North American Division',
+            'Marketing;Sales',
+        );
+
+        $elem = new Compound('ORG');
+        $elem->setParts($arr);
+
+        $this->assertEquals("ORG:ABC\, Inc.;North American Division;Marketing\;Sales\r\n", $elem->serialize());
+
+    }
 }

--- a/tests/Sabre/VObject/PropertyTest.php
+++ b/tests/Sabre/VObject/PropertyTest.php
@@ -169,6 +169,14 @@ class PropertyTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    public function testSerializeEscape() {
+
+        $property = new Property('propname','propvalue\escaped');
+
+        $this->assertEquals("PROPNAME:propvalue\\\\escaped\r\n",$property->serialize());
+
+    }
+
     public function testSerializeLongLine() {
 
         $value = str_repeat('!',200);

--- a/tests/Sabre/VObject/RecurrenceIteratorTest.php
+++ b/tests/Sabre/VObject/RecurrenceIteratorTest.php
@@ -1291,7 +1291,7 @@ class RecurrenceIteratorTest extends \PHPUnit_Framework_TestCase {
 
         }
 
-        $tz = new DateTimeZone('GMT');
+        $tz = new DateTimeZone('UTC');
         $this->assertEquals(array(
             new DateTime('2012-01-07 12:00:00',$tz),
             new DateTime('2012-01-08 12:00:00',$tz),
@@ -1356,7 +1356,7 @@ class RecurrenceIteratorTest extends \PHPUnit_Framework_TestCase {
 
         }
 
-        $tz = new DateTimeZone('GMT');
+        $tz = new DateTimeZone('UTC');
         $this->assertEquals(array(
             new DateTime('2012-01-12 12:00:00',$tz),
             new DateTime('2012-01-13 12:00:00',$tz),

--- a/tests/Sabre/VObject/TimeZoneUtilTest.php
+++ b/tests/Sabre/VObject/TimeZoneUtilTest.php
@@ -144,7 +144,12 @@ HI;
     function testTimezoneOffset() {
 
         $tz = TimeZoneUtil::getTimeZone('GMT-0400', null, true);
-        $ex = new \DateTimeZone('Etc/GMT-4');
+
+        if (version_compare(PHP_VERSION, '5.5.10', '>=')) {
+            $ex = new \DateTimeZone('-04:00');
+        } else {
+            $ex = new \DateTimeZone('Etc/GMT-4');
+        }
         $this->assertEquals($ex->getName(), $tz->getName());
 
     }

--- a/tests/Sabre/VObject/TimeZoneUtilTest.php
+++ b/tests/Sabre/VObject/TimeZoneUtilTest.php
@@ -294,7 +294,11 @@ END:VCALENDAR
 HI;
 
         $tz = TimeZoneUtil::getTimeZone('/freeassociation.sourceforge.net/Tzfile/SystemV/EST5EDT', Reader::read($vobj), true);
-        $ex = new \DateTimeZone('EST5EDT');
+        if (version_compare(PHP_VERSION, '5.5.10', '>=')) {
+            $ex = new \DateTimeZone('America/New_York');
+        } else {
+            $ex = new \DateTimeZone('EST5EDT');
+        }
         $this->assertEquals($ex->getName(), $tz->getName());
 
     }


### PR DESCRIPTION
This is a fallow-up to my previous pull request https://github.com/fruux/sabre-vobject/pull/66 now with unit tests. It fixes the wrong double-escaping of compound properties with commas and semicolons.