### PR TITLE
Skip the BOM if exists

### DIFF
--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -97,6 +97,16 @@ class MimeDir extends Parser {
     protected function parseDocument() {
 
         $line = $this->readLine();
+
+        // BOM is ZERO WIDTH NO-BREAK SPACE (U+FEFF).
+        // It's 0xEF 0xBB 0xBF in UTF-8 hex.
+        if (   3 <= strlen($line)
+            && ord($line[0]) === 0xef
+            && ord($line[1]) === 0xbb
+            && ord($line[2]) === 0xbf) {
+            $line = substr($line, 3);
+        }
+
         switch(strtoupper($line)) {
             case 'BEGIN:VCALENDAR' :
                 $class = isset(VCalendar::$componentMap['VCALENDAR'])

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -437,7 +437,7 @@ ICS;
 
     public function testReadBOM() {
 
-        $data = "﻿BEGIN:VCALENDAR\r\nEND:VCALENDAR";
+        $data = chr(0xef) . chr(0xbb) . chr(0xbf) . "BEGIN:VCALENDAR\r\nEND:VCALENDAR";
         $result = Reader::read($data);
 
         $this->assertInstanceOf('Sabre\\VObject\\Component', $result);

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -435,4 +435,15 @@ ICS;
 
     }
 
+    public function testReadBOM() {
+
+        $data = "﻿BEGIN:VCALENDAR\r\nEND:VCALENDAR";
+        $result = Reader::read($data);
+
+        $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
+        $this->assertEquals('VCALENDAR', $result->name);
+        $this->assertEquals(0, count($result->children));
+
+    }
+
 }

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -125,7 +125,6 @@ class ReaderTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-
     /**
      * @expectedException Sabre\VObject\ParseException
      */
@@ -154,6 +153,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('propValue', $result->children[0]->getValue());
 
     }
+
     function testReadNestedComponent() {
 
         $data = array(
@@ -294,6 +294,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('paramvalue', $result->parameters['PARAMNAME']->getValue());
 
     }
+
     function testReadPropertyParameterNewLines() {
 
         $data = "BEGIN:VCALENDAR\r\nPROPNAME;PARAMNAME=paramvalue1^nvalue2^^nvalue3:propValue\r\nEND:VCALENDAR";
@@ -354,7 +355,6 @@ class ReaderTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals($expected, $result->serialize());
 
-
     }
 
     function testReadWithInvalidLine() {
@@ -385,7 +385,6 @@ class ReaderTest extends \PHPUnit_Framework_TestCase {
         ));
 
         $this->assertEquals($expected, $result->serialize());
-
 
     }
 


### PR DESCRIPTION
Fix https://github.com/fruux/sabre-vobject/issues/175.
Fix https://github.com/owncloud/contacts/issues/635.

We skip the [BOM](http://graphemica.com/FEFF) if exists.

This PR addresses only `Parser/MimeDir.php` since I don't think it is needed in `Parser/Json.php` nor (the incoming) `Parser/Xml.php`.