### PR TITLE
Fix double-escaping of , and ; in compound properties

### DIFF
--- a/lib/Sabre/VObject/Property.php
+++ b/lib/Sabre/VObject/Property.php
@@ -195,6 +195,15 @@ class Property extends Node {
             '\n',
             '',
         );
+
+        // avoid double-escaping of \, and \; from Compound properties
+        if (method_exists($this, 'setParts')) {
+            $src[] = '\\\\,';
+            $out[] = '\\,';
+            $src[] = '\\\\;';
+            $out[] = '\\;';
+        }
+
         $str.=':' . str_replace($src, $out, $this->value);
 
         $out = '';

--- a/tests/Sabre/VObject/Property/CompoundTest.php
+++ b/tests/Sabre/VObject/Property/CompoundTest.php
@@ -56,4 +56,19 @@ class CompoundTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(0, count($elem->getParts()));
 
     }
+
+    function testSerialize() {
+
+        $arr = array(
+            'ABC, Inc.',
+            'North American Division',
+            'Marketing;Sales',
+        );
+
+        $elem = new Compound('ORG');
+        $elem->setParts($arr);
+
+        $this->assertEquals("ORG:ABC\, Inc.;North American Division;Marketing\;Sales\r\n", $elem->serialize());
+
+    }
 }

--- a/tests/Sabre/VObject/PropertyTest.php
+++ b/tests/Sabre/VObject/PropertyTest.php
@@ -169,6 +169,14 @@ class PropertyTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    public function testSerializeEscape() {
+
+        $property = new Property('propname','propvalue\escaped');
+
+        $this->assertEquals("PROPNAME:propvalue\\\\escaped\r\n",$property->serialize());
+
+    }
+
     public function testSerializeLongLine() {
 
         $value = str_repeat('!',200);


### PR DESCRIPTION
This is a fresh version of my previous pull requests #66 and #81. It fixes the wrong double-escaping of compound properties with commas and semicolons for the 2.1 branch of vobject. This is a proposed fix for issue #94.