### PR TITLE
Implement xCard support

### DIFF
--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -439,23 +439,50 @@ class VCard extends VObject\Document {
      */
     function xmlSerialize(Xml\Writer $writer) {
 
-        $writer->startElement(strtolower($this->name));
+        $propertiesByGroup = [];
 
         foreach ($this->children as $property) {
 
-            switch ($property->name) {
+            $group = $property->group;
 
-                case 'VERSION':
-                    continue;
+            if (!isset($propertiesByGroup[$group])) {
+                $propertiesByGroup[$group] = [];
+            }
 
-                case 'XML':
-                    $value = $property->getParts();
-                    $writer->writeRaw('  ' . $value[0] . "\n ");
-                    break;
+            $propertiesByGroup[$group][] = $property;
 
-                default:
-                    $property->xmlSerialize($writer);
+        }
 
+        $writer->startElement(strtolower($this->name));
+
+        foreach ($propertiesByGroup as $group => $properties) {
+
+            if (!empty($group)) {
+
+                $writer->startElement('group');
+                $writer->writeAttribute('name', strtolower($group));
+
+            }
+
+            foreach ($properties as $property) {
+                switch ($property->name) {
+
+                    case 'VERSION':
+                        continue;
+
+                    case 'XML':
+                        $value = $property->getParts();
+                        $writer->writeRaw('  ' . $value[0] . "\n ");
+                        break;
+
+                    default:
+                        $property->xmlSerialize($writer);
+
+                }
+            }
+
+            if (!empty($group)) {
+                $writer->endElement();
             }
 
         }

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -72,7 +72,7 @@ class VCard extends VObject\Document {
         'BDAY'    => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
         'ADR'     => 'Sabre\\VObject\\Property\\Text',
         'LABEL'   => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'TEL'     => 'Sabre\\VObject\\Property\\FlatText',
+        'TEL'     => 'Sabre\\VObject\\Property\\Uri',
         'EMAIL'   => 'Sabre\\VObject\\Property\\FlatText',
         'MAILER'  => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
         'GEO'     => 'Sabre\\VObject\\Property\\FlatText',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -443,11 +443,20 @@ class VCard extends VObject\Document {
 
         foreach ($this->children as $property) {
 
-            if ($property->name === 'VERSION') {
-                continue;
-            }
+            switch ($property->name) {
 
-            $property->xmlSerialize($writer);
+                case 'VERSION':
+                    continue;
+
+                case 'XML':
+                    $value = $property->getParts();
+                    $writer->writeRaw('  ' . $value[0] . "\n ");
+                    break;
+
+                default:
+                    $property->xmlSerialize($writer);
+
+            }
 
         }
 

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -481,6 +481,7 @@ class VCard extends VObject\Document {
 
                     default:
                         $property->xmlSerialize($writer);
+                        break;
 
                 }
             }

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -75,7 +75,7 @@ class VCard extends VObject\Document {
         'TEL'     => 'Sabre\\VObject\\Property\\Uri',
         'EMAIL'   => 'Sabre\\VObject\\Property\\FlatText',
         'MAILER'  => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'GEO'     => 'Sabre\\VObject\\Property\\FlatText',
+        'GEO'     => 'Sabre\\VObject\\Property\\Uri',
         'TITLE'   => 'Sabre\\VObject\\Property\\FlatText',
         'ROLE'    => 'Sabre\\VObject\\Property\\FlatText',
         'LOGO'    => 'Sabre\\VObject\\Property\\Binary',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -3,7 +3,8 @@
 namespace Sabre\VObject\Component;
 
 use
-    Sabre\VObject;
+    Sabre\VObject,
+    Sabre\Xml;
 
 /**
  * The VCard component
@@ -426,6 +427,31 @@ class VCard extends VObject\Document {
             strtolower($this->name),
             $properties,
         ];
+
+    }
+
+    /**
+     * This method serializes the data into XML. This is used to create xCard or
+     * xCal documents.
+     *
+     * @param Xml\Writer $writer  XML writer.
+     * @return void
+     */
+    function xmlSerialize(Xml\Writer $writer) {
+
+        $writer->startElement(strtolower($this->name));
+
+        foreach ($this->children as $property) {
+
+            if ($property->name === 'VERSION') {
+                continue;
+            }
+
+            $property->xmlSerialize($writer);
+
+        }
+
+        $writer->endElement();
 
     }
 

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -72,10 +72,10 @@ class VCard extends VObject\Document {
         'BDAY'    => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
         'ADR'     => 'Sabre\\VObject\\Property\\Text',
         'LABEL'   => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'TEL'     => 'Sabre\\VObject\\Property\\Uri',
+        'TEL'     => 'Sabre\\VObject\\Property\\FlatText',
         'EMAIL'   => 'Sabre\\VObject\\Property\\FlatText',
         'MAILER'  => 'Sabre\\VObject\\Property\\FlatText', // Removed in vCard 4.0
-        'GEO'     => 'Sabre\\VObject\\Property\\Uri',
+        'GEO'     => 'Sabre\\VObject\\Property\\FlatText',
         'TITLE'   => 'Sabre\\VObject\\Property\\FlatText',
         'ROLE'    => 'Sabre\\VObject\\Property\\FlatText',
         'LOGO'    => 'Sabre\\VObject\\Property\\Binary',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -476,7 +476,8 @@ class VCard extends VObject\Document {
 
                     case 'XML':
                         $value = $property->getParts();
-                        $writer->writeRaw('  ' . $value[0] . "\n ");
+                        $fragment = new Xml\Element\XmlFragment($value[0]);
+                        $writer->write($fragment);
                         break;
 
                     default:

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -102,6 +102,7 @@ class VCard extends VObject\Document {
         'FBURL'        => 'Sabre\\VObject\\Property\\Uri',
         'CAPURI'       => 'Sabre\\VObject\\Property\\Uri',
         'CALURI'       => 'Sabre\\VObject\\Property\\Uri',
+        'CALADRURI'    => 'Sabre\\VObject\\Property\\Uri',
 
         // rfc4770 properties
         'IMPP'         => 'Sabre\\VObject\\Property\\Uri',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -107,6 +107,7 @@ class VCard extends VObject\Document {
         'IMPP'         => 'Sabre\\VObject\\Property\\Uri',
 
         // vCard 4.0 properties
+        'SOURCE'       => 'Sabre\\VObject\\Property\\Uri',
         'XML'          => 'Sabre\\VObject\\Property\\FlatText',
         'ANNIVERSARY'  => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime',
         'CLIENTPIDMAP' => 'Sabre\\VObject\\Property\\Text',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -115,6 +115,7 @@ class VCard extends VObject\Document {
         'GENDER'       => 'Sabre\\VObject\\Property\\Text',
         'KIND'         => 'Sabre\\VObject\\Property\\FlatText',
         'MEMBER'       => 'Sabre\\VObject\\Property\\Uri',
+        'RELATED'      => 'Sabre\\VObject\\Property\\Uri',
 
         // rfc6474 properties
         'BIRTHPLACE'    => 'Sabre\\VObject\\Property\\FlatText',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -84,7 +84,7 @@ class VCard extends VObject\Document {
         'ORG'     => 'Sabre\\VObject\\Property\\Text',
         'NOTE'    => 'Sabre\\VObject\\Property\\FlatText',
         'REV'     => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
-        'SOUND'   => 'Sabre\\VObject\\Property\\FlatText',
+        'SOUND'   => 'Sabre\\VObject\\Property\\Uri',
         'URL'     => 'Sabre\\VObject\\Property\\Uri',
         'UID'     => 'Sabre\\VObject\\Property\\FlatText',
         'VERSION' => 'Sabre\\VObject\\Property\\FlatText',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -84,7 +84,7 @@ class VCard extends VObject\Document {
         'ORG'     => 'Sabre\\VObject\\Property\\Text',
         'NOTE'    => 'Sabre\\VObject\\Property\\FlatText',
         'REV'     => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
-        'SOUND'   => 'Sabre\\VObject\\Property\\Uri',
+        'SOUND'   => 'Sabre\\VObject\\Property\\FlatText',
         'URL'     => 'Sabre\\VObject\\Property\\Uri',
         'UID'     => 'Sabre\\VObject\\Property\\FlatText',
         'VERSION' => 'Sabre\\VObject\\Property\\FlatText',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -438,8 +438,8 @@ class VCard extends VObject\Document {
     function getClassNameForPropertyName($propertyName) {
 
         $className = parent::getClassNameForPropertyName($propertyName);
-        // In vCard 4, BINARY no longer exists, and we need URI instead.
 
+        // In vCard 4, BINARY no longer exists, and we need URI instead.
         if ($className == 'Sabre\\VObject\\Property\\Binary' && $this->getDocumentType()===self::VCARD40) {
             return 'Sabre\\VObject\\Property\\Uri';
         }

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -114,6 +114,7 @@ class VCard extends VObject\Document {
         'LANG'         => 'Sabre\\VObject\\Property\\VCard\\LanguageTag',
         'GENDER'       => 'Sabre\\VObject\\Property\\Text',
         'KIND'         => 'Sabre\\VObject\\Property\\FlatText',
+        'MEMBER'       => 'Sabre\\VObject\\Property\\Uri',
 
         // rfc6474 properties
         'BIRTHPLACE'    => 'Sabre\\VObject\\Property\\FlatText',

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -88,7 +88,7 @@ class DateTimeParser {
      */
     static function parseDuration($duration, $asString = false) {
 
-        $result = preg_match('/^(?P<plusminus>\+|-)?P((?P<week>\d+)W)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?$/', $duration, $matches);
+        $result = preg_match('/^(?<plusminus>\+|-)?P((?<week>\d+)W)?((?<day>\d+)D)?(T((?<hour>\d+)H)?((?<minute>\d+)M)?((?<second>\d+)S)?)?$/', $duration, $matches);
         if (!$result) {
             throw new LogicException('The supplied iCalendar duration value is incorrect: ' . $duration);
         }
@@ -263,17 +263,17 @@ class DateTimeParser {
         $regex = '/^
             (?:  # date part
                 (?:
-                    (?: (?P<year> [0-9]{4}) (?: -)?| --)
-                    (?P<month> [0-9]{2})?
+                    (?: (?<year> [0-9]{4}) (?: -)?| --)
+                    (?<month> [0-9]{2})?
                 |---)
-                (?P<date> [0-9]{2})?
+                (?<date> [0-9]{2})?
             )?
             (?:T  # time part
-                (?P<hour> [0-9]{2} | -)
-                (?P<minute> [0-9]{2} | -)?
-                (?P<second> [0-9]{2})?
+                (?<hour> [0-9]{2} | -)
+                (?<minute> [0-9]{2} | -)?
+                (?<second> [0-9]{2})?
 
-                (?P<timezone> # timezone offset
+                (?<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{4})
 
@@ -288,17 +288,17 @@ class DateTimeParser {
             // Attempting to parse the extended format.
             $regex = '/^
                 (?: # date part
-                    (?: (?P<year> [0-9]{4}) - | -- )
-                    (?P<month> [0-9]{2}) -
-                    (?P<date> [0-9]{2})
+                    (?: (?<year> [0-9]{4}) - | -- )
+                    (?<month> [0-9]{2}) -
+                    (?<date> [0-9]{2})
                 )?
                 (?:T # time part
 
-                    (?: (?P<hour> [0-9]{2}) : | -)
-                    (?: (?P<minute> [0-9]{2}) : | -)?
-                    (?P<second> [0-9]{2})?
+                    (?: (?<hour> [0-9]{2}) : | -)
+                    (?: (?<minute> [0-9]{2}) : | -)?
+                    (?<second> [0-9]{2})?
 
-                    (?P<timezone> # timezone offset
+                    (?<timezone> # timezone offset
 
                         Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
 
@@ -383,11 +383,11 @@ class DateTimeParser {
     static function parseVCardTime($date) {
 
         $regex = '/^
-            (?P<hour> [0-9]{2} | -)
-            (?P<minute> [0-9]{2} | -)?
-            (?P<second> [0-9]{2})?
+            (?<hour> [0-9]{2} | -)
+            (?<minute> [0-9]{2} | -)?
+            (?<second> [0-9]{2})?
 
-            (?P<timezone> # timezone offset
+            (?<timezone> # timezone offset
 
                 Z | (?: \+|-)(?: [0-9]{4})
 
@@ -399,11 +399,11 @@ class DateTimeParser {
 
             // Attempting to parse the extended format.
             $regex = '/^
-                (?: (?P<hour> [0-9]{2}) : | -)
-                (?: (?P<minute> [0-9]{2}) : | -)?
-                (?P<second> [0-9]{2})?
+                (?: (?<hour> [0-9]{2}) : | -)
+                (?: (?<minute> [0-9]{2}) : | -)?
+                (?<second> [0-9]{2})?
 
-                (?P<timezone> # timezone offset
+                (?<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
 

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -94,11 +94,12 @@ class DateTimeParser {
         }
 
         if (!$asString) {
+
             $invert = false;
+
             if ($matches['plusminus']==='-') {
                 $invert = true;
             }
-
 
             $parts = [
                 'week',
@@ -107,46 +108,55 @@ class DateTimeParser {
                 'minute',
                 'second',
             ];
+
             foreach($parts as $part) {
                 $matches[$part] = isset($matches[$part])&&$matches[$part]?(int)$matches[$part]:0;
             }
-
 
             // We need to re-construct the $duration string, because weeks and
             // days are not supported by DateInterval in the same string.
             $duration = 'P';
             $days = $matches['day'];
+
             if ($matches['week']) {
                 $days+=$matches['week']*7;
             }
-            if ($days)
+
+            if ($days) {
                 $duration.=$days . 'D';
+            }
 
             if ($matches['minute'] || $matches['second'] || $matches['hour']) {
+
                 $duration.='T';
 
-                if ($matches['hour'])
+                if ($matches['hour']) {
                     $duration.=$matches['hour'].'H';
+                }
 
-                if ($matches['minute'])
+                if ($matches['minute']) {
                     $duration.=$matches['minute'].'M';
+                }
 
-                if ($matches['second'])
+                if ($matches['second']) {
                     $duration.=$matches['second'].'S';
+                }
 
             }
 
             if ($duration==='P') {
                 $duration = 'PT0S';
             }
+
             $iv = new DateInterval($duration);
-            if ($invert) $iv->invert = true;
+
+            if ($invert) {
+                $iv->invert = true;
+            }
 
             return $iv;
 
         }
-
-
 
         $parts = [
             'week',
@@ -157,6 +167,7 @@ class DateTimeParser {
         ];
 
         $newDur = '';
+
         foreach($parts as $part) {
             if (isset($matches[$part]) && $matches[$part]) {
                 $newDur.=' '.$matches[$part] . ' ' . $part . 's';
@@ -164,9 +175,11 @@ class DateTimeParser {
         }
 
         $newDur = ($matches['plusminus']==='-'?'-':'+') . trim($newDur);
+
         if ($newDur === '+') {
             $newDur = '+0 seconds';
         };
+
         return $newDur;
 
     }

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -217,7 +217,7 @@ class DateTimeParser {
      * Almost any part of the string may be omitted. It's for example legal to
      * just specify seconds, leave out the year, etc.
      *
-     * Timezone is either returned as 'Z' or as '+08:00'
+     * Timezone is either returned as 'Z' or as '+0800'
      *
      * For any non-specified values null is returned.
      *

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -355,7 +355,9 @@ class Parameter extends Node {
      */
     function xmlSerialize(Xml\Writer $writer) {
 
-        $writer->writeElement('text', $this->value);
+        foreach (explode(',', $this->value) as $value) {
+            $writer->writeElement('text', $value);
+        }
 
     }
 

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -355,7 +355,7 @@ class Parameter extends Node {
      */
     function xmlSerialize(Xml\Writer $writer) {
 
-        $writer->write($this->value);
+        $writer->writeElement('text', $this->value);
 
     }
 

--- a/lib/Parameter.php
+++ b/lib/Parameter.php
@@ -189,7 +189,7 @@ class Parameter extends Node {
      * Returns the current value
      *
      * This method will always return a string, or null. If there were multiple
-     * values, it will automatically concatinate them (separated by comma).
+     * values, it will automatically concatenate them (separated by comma).
      *
      * @return string|null
      */

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -70,7 +70,7 @@ class XML extends Parser {
      * @param resource|string $input
      * @param int $options
      * @throws \Exception
-     * @return Generator of Sabre\VObject\Document
+     * @return Sabre\VObject\Document
      */
     public function parse($input = null, $options = 0) {
 
@@ -92,8 +92,6 @@ class XML extends Parser {
                 $this->root = new VCalendar([], false);
                 $this->pointer = &$this->input['value'][0];
                 $this->parseVCalendarComponents($this->root);
-
-                yield $this->root;
                 break;
 
             case '{' . self::XCARD_NAMESPACE . '}vcards':
@@ -103,7 +101,8 @@ class XML extends Parser {
                     $this->pointer  = &$vCard;
                     $this->parseVCardComponents($this->root);
 
-                    yield $this->root;
+                    // We just parse the first <vcard /> element.
+                    break;
 
                 }
                 break;
@@ -113,7 +112,7 @@ class XML extends Parser {
 
         }
 
-        return;
+        return $this->root;
     }
 
     /**

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -249,7 +249,6 @@ class XML extends Parser {
 
                 case 'xcal:geo':
                     $propertyType               = 'float';
-
                     $propertyValue['latitude']  = 0;
                     $propertyValue['longitude'] = 0;
 

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -241,10 +241,15 @@ class XML extends Parser {
 
             }
 
-            switch ($propertyName) {
+            $propertyNameExtended = ($this->root instanceof VCalendar
+                                      ? 'xcal'
+                                      : 'xcard') . ':' . $propertyName;
 
-                case 'geo':
+            switch ($propertyNameExtended) {
+
+                case 'xcal:geo':
                     $propertyType               = 'float';
+
                     $propertyValue['latitude']  = 0;
                     $propertyValue['longitude'] = 0;
 
@@ -254,7 +259,7 @@ class XML extends Parser {
                     }
                     break;
 
-                case 'request-status':
+                case 'xcal:request-status':
                     $propertyType = 'text';
 
                     foreach ($xmlProperty['value'] as $xmlRequestChild) {
@@ -263,21 +268,21 @@ class XML extends Parser {
                     }
                     break;
 
-                case 'freebusy':
+                case 'xcal:freebusy':
                     $propertyType = 'freebusy';
                     // We don't break because we only want to set
                     // another property type.
 
-                case 'categories':
-                case 'resources':
-                case 'exdate':
+                case 'xcal:categories':
+                case 'xcal:resources':
+                case 'xcal:exdate':
                     foreach ($xmlProperty['value'] as $specialChild) {
                         $propertyValue[static::getTagName($specialChild['name'])]
                             = $specialChild['value'];
                     }
                     break;
 
-                case 'rdate':
+                case 'xcal:rdate':
                     $propertyType = 'date-time';
 
                     foreach ($xmlProperty['value'] as $specialChild) {

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -205,6 +205,8 @@ class XML extends Parser {
                     || 'parameters' !== static::getTagName($xmlPropertyChild['name']))
                     continue;
 
+                $xmlParameters = $xmlPropertyChild['value'];
+
                 foreach ($xmlParameters as $xmlParameter) {
                     $propertyParameters[static::getTagName($xmlParameter['name'])]
                         = $xmlParameter['value'][0]['value'];

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -207,8 +207,16 @@ class XML extends Parser {
                 $xmlParameters = $xmlPropertyChild['value'];
 
                 foreach ($xmlParameters as $xmlParameter) {
+
+                    $propertyParameterValues = [];
+
+                    foreach($xmlParameter['value'] as $xmlParameterValues) {
+                        $propertyParameterValues[] = $xmlParameterValues['value'];
+                    }
+
                     $propertyParameters[static::getTagName($xmlParameter['name'])]
-                        = $xmlParameter['value'][0]['value'];
+                        = implode(',', $propertyParameterValues);
+
                 }
 
                 array_splice($xmlProperty['value'], $i, 1);

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -117,9 +117,9 @@ class XML extends Parser {
     }
 
     /**
-     * Parse a vCalendar.
+     * Parse a xCalendar component.
      *
-     * @param Sabre\VObject\Component $parentComponent
+     * @param Component $parentComponent
      * @return void
      */
     protected function parseVCalendarComponents(Component $parentComponent) {
@@ -130,7 +130,7 @@ class XML extends Parser {
 
                 case 'properties':
                     $this->pointer = &$children['value'];
-                    $this->parseProperty($parentComponent);
+                    $this->parseProperties($parentComponent);
                     break;
 
                 case 'components':
@@ -143,19 +143,25 @@ class XML extends Parser {
     }
 
     /**
-     * Parse a vCard.
+     * Parse a xCard component.
      *
-     * @param Sabre\VObject\Component $parentComponent
+     * @param Component $parentComponent
      * @return void
      */
     protected function parseVCardComponents(Component $parentComponent) {
 
         $this->pointer = &$this->pointer['value'];
-        $this->parseProperty($parentComponent);
+        $this->parseProperties($parentComponent);
 
     }
 
-    protected function parseProperty(Component $parentComponent) {
+    /**
+     * Parse xCalendar and xCard properties.
+     *
+     * @param Component $parentComponent
+     * @return void
+     */
+    protected function parseProperties(Component $parentComponent) {
 
         foreach ($this->pointer as $xmlProperty) {
 
@@ -166,6 +172,7 @@ class XML extends Parser {
             $propertyParameters = [];
             $propertyType       = 'text';
 
+            // A property which is not part of the standard.
             if (   $namespace !== self::XCAL_NAMESPACE
                 && $namespace !== self::XCARD_NAMESPACE) {
 
@@ -191,6 +198,7 @@ class XML extends Parser {
                 continue;
             }
 
+            // Collect parameters.
             foreach ($xmlProperty['value'] as $i => $xmlPropertyChild) {
 
                 if (   !is_array($xmlPropertyChild)
@@ -286,19 +294,12 @@ class XML extends Parser {
 
     }
 
-    protected function createProperty(Component $parentComponent, $name, $parameters, $type, $value) {
-
-        $property = $this->root->createProperty(
-            $name,
-            null,
-            $parameters,
-            $type
-        );
-        $parentComponent->add($property);
-        $property->setXmlValue($value);
-
-    }
-
+    /**
+     * Parse a component.
+     *
+     * @param Component $parentComponent
+     * @return void
+     */
     protected function parseComponent(Component $parentComponent) {
 
         $components = $this->pointer['value'] ?: [];
@@ -318,6 +319,29 @@ class XML extends Parser {
             $parentComponent->add($currentComponent);
 
         }
+
+    }
+
+    /**
+     * Create a property.
+     *
+     * @param Component $parentComponent
+     * @param string $name
+     * @param array $parameters
+     * @param string $type
+     * @param mixed $value
+     * @return void
+     */
+    protected function createProperty(Component $parentComponent, $name, $parameters, $type, $value) {
+
+        $property = $this->root->createProperty(
+            $name,
+            null,
+            $parameters,
+            $type
+        );
+        $parentComponent->add($property);
+        $property->setXmlValue($value);
 
     }
 

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -163,7 +163,7 @@ class XML extends Parser {
      */
     protected function parseProperties(Component $parentComponent, $propertyNamePrefix = '') {
 
-        foreach ($this->pointer as $xmlProperty) {
+        foreach ($this->pointer ?: [] as $xmlProperty) {
 
             list($namespace, $tagName) = SabreXml\Util::parseClarkNotation($xmlProperty['name']);
 

--- a/lib/Parser/XML.php
+++ b/lib/Parser/XML.php
@@ -158,9 +158,10 @@ class XML extends Parser {
      * Parse xCalendar and xCard properties.
      *
      * @param Component $parentComponent
+     * @param string  $propertyNamePrefix
      * @return void
      */
-    protected function parseProperties(Component $parentComponent) {
+    protected function parseProperties(Component $parentComponent, $propertyNamePrefix = '') {
 
         foreach ($this->pointer as $xmlProperty) {
 
@@ -195,6 +196,23 @@ class XML extends Parser {
                 );
 
                 continue;
+            }
+
+            // xCard group.
+            if ($propertyName === 'group') {
+
+                if (!isset($xmlProperty['attributes']['name'])) {
+                    continue;
+                }
+
+                $this->pointer = &$xmlProperty['value'];
+                $this->parseProperties(
+                    $parentComponent,
+                    $xmlProperty['attributes']['name'] . '.'
+                );
+
+                continue;
+
             }
 
             // Collect parameters.
@@ -293,7 +311,7 @@ class XML extends Parser {
 
             $this->createProperty(
                 $parentComponent,
-                $propertyName,
+                $propertyNamePrefix . $propertyName,
                 $propertyParameters,
                 $propertyType,
                 $propertyValue

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -364,7 +364,7 @@ abstract class Property extends Node {
             foreach ($parameters as $parameter) {
 
                 $writer->startElement(strtolower($parameter->name));
-                $writer->writeElement('text', $parameter);
+                $writer->write($parameter);
                 $writer->endElement();
 
             }

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -387,8 +387,12 @@ abstract class Property extends Node {
      */
     protected function xmlSerializeValue(Xml\Writer $writer) {
 
-        foreach ($this->getJsonValue() as $value) {
-            $writer->writeElement(strtolower($this->getValueType()), $value);
+        $valueType = strtolower($this->getValueType());
+
+        foreach ($this->getJsonValue() as $values) {
+            foreach((array)$values as $value) {
+                $writer->writeElement($valueType, $value);
+            }
         }
 
     }

--- a/lib/Property/ICalendar/Recur.php
+++ b/lib/Property/ICalendar/Recur.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\VObject\Property\ICalendar;
 
-use Sabre\VObject\Property;
+use
+    Sabre\VObject\Property,
+    Sabre\Xml;
 
 /**
  * Recur property
@@ -165,6 +167,23 @@ class Recur extends Property {
             $values[strtolower($k)] = $v;
         }
         return [$values];
+
+    }
+
+    /**
+     * This method serializes only the value of a property. This is used to
+     * create xCard or xCal documents.
+     *
+     * @param Xml\Writer $writer  XML writer.
+     * @return void
+     */
+    protected function xmlSerializeValue(Xml\Writer $writer) {
+
+        $valueType = strtolower($this->getValueType());
+
+        foreach ($this->getJsonValue() as $value) {
+            $writer->writeElement($valueType, $value);
+        }
 
     }
 

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -339,6 +339,18 @@ class Text extends Property {
                 ]);
                 break;
 
+            case 'ADR':
+                $map([
+                    'pobox',
+                    'ext',
+                    'street',
+                    'locality',
+                    'region',
+                    'code',
+                    'country'
+                ]);
+                break;
+
             default:
                 parent::xmlSerializeValue($writer);
         }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -296,24 +296,23 @@ class Text extends Property {
      */
     protected function xmlSerializeValue(Xml\Writer $writer) {
 
+        $values = $this->getParts();
+
         // Special-casing the REQUEST-STATUS property.
         //
         // See:
         // http://tools.ietf.org/html/rfc6321#section-3.4.1.3
         if ($this->name === 'REQUEST-STATUS') {
 
-            $value = $this->getParts();
+            $writer->writeElement('code', $values[0]);
+            $writer->writeElement('description', $values[1]);
 
-            $writer->writeElement('code', $value[0]);
-            $writer->writeElement('description', $value[1]);
-
-            if (isset($value[2])) {
-                $writer->writeElement('data', $value[2]);
+            if (isset($values[2])) {
+                $writer->writeElement('data', $values[2]);
             }
 
         } elseif ($this->name === 'N') {
 
-            $values = $this->getParts();
             $mapping = [
                 'surname'    => !empty($values[0]) ? $values[0] : null,
                 'given'      => !empty($values[1]) ? $values[1] : null,

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -302,17 +302,16 @@ class Text extends Property {
         // http://tools.ietf.org/html/rfc6321#section-3.4.1.3
         if ($this->name === 'REQUEST-STATUS') {
 
-            $value = $this->getJsonValue();
+            $value = $this->getParts();
 
-            $writer->writeElement('code', $value[0][0]);
-            $writer->writeElement('description', $value[0][1]);
+            $writer->writeElement('code', $value[0]);
+            $writer->writeElement('description', $value[1]);
 
-            if (isset($value[0][2])) {
-                $writer->writeElement('data', $value[0][2]);
+            if (isset($value[2])) {
+                $writer->writeElement('data', $value[2]);
             }
 
-        }
-        else {
+        } else {
             parent::xmlSerializeValue($writer);
         }
 

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -39,6 +39,7 @@ class Text extends Property {
         'ADR',
         'ORG',
         'GENDER',
+        'CLIENTPIDMAP',
 
         // iCalendar
         'REQUEST-STATUS',
@@ -348,6 +349,13 @@ class Text extends Property {
                     'region',
                     'code',
                     'country'
+                ]);
+                break;
+
+            case 'CLIENTPIDMAP':
+                $map([
+                    'sourceid',
+                    'uri'
                 ]);
                 break;
 

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -325,6 +325,17 @@ class Text extends Property {
                 $writer->writeElement($name, $value);
             }
 
+        } elseif ($this->name === 'GENDER') {
+
+            $mapping = [
+                'sex'  => !empty($values[0]) ? $values[0] : null,
+                'text' => !empty($values[1]) ? $values[1] : null,
+            ];
+
+            foreach ($mapping as $name => $value) {
+                $writer->writeElement($name, $value);
+            }
+
         } else {
             parent::xmlSerializeValue($writer);
         }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -311,6 +311,21 @@ class Text extends Property {
                 $writer->writeElement('data', $value[2]);
             }
 
+        } elseif ($this->name === 'N') {
+
+            $values = $this->getParts();
+            $mapping = [
+                'surname'    => !empty($values[0]) ? $values[0] : null,
+                'given'      => !empty($values[1]) ? $values[1] : null,
+                'additional' => !empty($values[2]) ? $values[2] : null,
+                'prefix'     => !empty($values[3]) ? $values[3] : null,
+                'suffix'     => !empty($values[4]) ? $values[4] : null,
+            ];
+
+            foreach ($mapping as $name => $value) {
+                $writer->writeElement($name, $value);
+            }
+
         } else {
             parent::xmlSerializeValue($writer);
         }

--- a/lib/Property/Text.php
+++ b/lib/Property/Text.php
@@ -298,46 +298,49 @@ class Text extends Property {
 
         $values = $this->getParts();
 
-        // Special-casing the REQUEST-STATUS property.
-        //
-        // See:
-        // http://tools.ietf.org/html/rfc6321#section-3.4.1.3
-        if ($this->name === 'REQUEST-STATUS') {
-
-            $writer->writeElement('code', $values[0]);
-            $writer->writeElement('description', $values[1]);
-
-            if (isset($values[2])) {
-                $writer->writeElement('data', $values[2]);
+        $map = function($items) use($values, $writer) {
+            foreach ($items as $i => $item) {
+                $writer->writeElement(
+                    $item,
+                    !empty($values[$i]) ? $values[$i] : null
+                );
             }
+        };
 
-        } elseif ($this->name === 'N') {
+        switch ($this->name) {
 
-            $mapping = [
-                'surname'    => !empty($values[0]) ? $values[0] : null,
-                'given'      => !empty($values[1]) ? $values[1] : null,
-                'additional' => !empty($values[2]) ? $values[2] : null,
-                'prefix'     => !empty($values[3]) ? $values[3] : null,
-                'suffix'     => !empty($values[4]) ? $values[4] : null,
-            ];
+            // Special-casing the REQUEST-STATUS property.
+            //
+            // See:
+            // http://tools.ietf.org/html/rfc6321#section-3.4.1.3
+            case 'REQUEST-STATUS':
+                $writer->writeElement('code', $values[0]);
+                $writer->writeElement('description', $values[1]);
 
-            foreach ($mapping as $name => $value) {
-                $writer->writeElement($name, $value);
-            }
+                if (isset($values[2])) {
+                    $writer->writeElement('data', $values[2]);
+                }
+                break;
 
-        } elseif ($this->name === 'GENDER') {
+            case 'N':
+                $map([
+                    'surname',
+                    'given',
+                    'additional',
+                    'prefix',
+                    'suffix'
+                ]);
+                break;
 
-            $mapping = [
-                'sex'  => !empty($values[0]) ? $values[0] : null,
-                'text' => !empty($values[1]) ? $values[1] : null,
-            ];
+            case 'GENDER':
+                $map([
+                    'sex',
+                    'text'
+                ]);
+                break;
 
-            foreach ($mapping as $name => $value) {
-                $writer->writeElement($name, $value);
-            }
-
-        } else {
-            parent::xmlSerializeValue($writer);
+            default:
+                parent::xmlSerializeValue($writer);
         }
 
     }

--- a/lib/Property/Uri.php
+++ b/lib/Property/Uri.php
@@ -72,7 +72,7 @@ class Uri extends Text {
             }
             $this->value = $newVal;
         } else {
-            $this->value = $val;
+            $this->value = strtr($val, ['\,' => ',']);
         }
 
     }
@@ -85,10 +85,12 @@ class Uri extends Text {
     public function getRawMimeDirValue() {
 
         if (is_array($this->value)) {
-            return $this->value[0];
+            $value = $this->value[0];
         } else {
-            return $this->value;
+            $value = $this->value;
         }
+
+        return strtr($value, [',' => '\,']);
 
     }
 

--- a/lib/Property/VCard/DateAndOrTime.php
+++ b/lib/Property/VCard/DateAndOrTime.php
@@ -2,11 +2,13 @@
 
 namespace Sabre\VObject\Property\VCard;
 
-use Sabre\VObject\DateTimeParser;
-use Sabre\VObject\Property;
-use DateTimeInterface;
-use DateTimeImmutable;
-use DateTime;
+use
+    Sabre\VObject\DateTimeParser,
+    Sabre\VObject\Property,
+    Sabre\Xml,
+    DateTimeInterface,
+    DateTimeImmutable,
+    DateTime;
 
 /**
  * DateAndOrTime property
@@ -245,6 +247,90 @@ class DateAndOrTime extends Property {
         }
 
         return [$dateStr];
+
+    }
+
+    /**
+     * This method serializes only the value of a property. This is used to
+     * create xCard or xCal documents.
+     *
+     * @param Xml\Writer $writer  XML writer.
+     * @return void
+     */
+    protected function xmlSerializeValue(Xml\Writer $writer) {
+
+        $valueType = strtolower($this->getValueType());
+        $parts     = DateTimeParser::parseVCardDateTime($this->getValue());
+        $value     = '';
+
+        // $d = defined
+        $d = function($part) use($parts) {
+            return !is_null($parts[$part]);
+        };
+
+        // $r = read
+        $r = function($part) use($parts) {
+            return $parts[$part];
+        };
+
+        // From the Relax NG Schema.
+        //
+        // # 4.3.1
+        // value-date = element date {
+        //     xsd:string { pattern = "\d{8}|\d{4}-\d\d|--\d\d(\d\d)?|---\d\d" }
+        //   }
+        if (   ( $d('year') ||  $d('month')  ||  $d('date'))
+            && (!$d('hour') && !$d('minute') && !$d('second') && !$d('timezone'))) {
+
+            if ($d('year') && $d('month') && $d('date')) {
+                $value .= $r('year') . $r('month') . $r('date');
+            } elseif ($d('year') && $d('month') && !$d('date')) {
+                $value .= $r('year') . '-' . $r('month');
+            } elseif (!$d('year') && $d('month')) {
+                $value .= '--' . $r('month') . $r('date');
+            } elseif (!$d('year') && !$d('month') && $d('date')) {
+                $value .= '---' . $r('date');
+            }
+
+        // # 4.3.2
+        // value-time = element time {
+        //     xsd:string { pattern = "(\d\d(\d\d(\d\d)?)?|-\d\d(\d\d?)|--\d\d)"
+        //                          ~ "(Z|[+\-]\d\d(\d\d)?)?" }
+        //   }
+        } elseif (   (!$d('year') && !$d('month')  && !$d('date'))
+                  && ( $d('hour') ||  $d('minute') ||  $d('second'))) {
+
+            if ($d('hour')) {
+                $value .= $r('hour') . $r('minute') . $r('second');
+            } elseif ($d('minute')) {
+                $value .= '-' . $r('minute') . $r('second');
+            } elseif ($d('second')) {
+                $value .= '--' . $r('second');
+            }
+
+            $value .= $r('timezone');
+
+        // # 4.3.3
+        // value-date-time = element date-time {
+        //     xsd:string { pattern = "(\d{8}|--\d{4}|---\d\d)T\d\d(\d\d(\d\d)?)?"
+        //                          ~ "(Z|[+\-]\d\d(\d\d)?)?" }
+        //   }
+        } elseif ($d('date') && $d('hour')) {
+
+            if ($d('year') && $d('month') && $d('date')) {
+                $value .= $r('year') . $r('month') . $r('date');
+            } elseif (!$d('year') && $d('month') && $d('date')) {
+                $value .= '--' . $r('month') . $r('date');
+            } elseif (!$d('year') && !$d('month') && $d('date')) {
+                $value .= '---' . $r('date');
+            }
+
+            $value .= 'T' . $r('hour') . $r('minute') . $r('second') .
+                      $r('timezone');
+
+        }
+
+        $writer->writeElement($valueType, $value);
 
     }
 

--- a/lib/Property/VCard/DateAndOrTime.php
+++ b/lib/Property/VCard/DateAndOrTime.php
@@ -260,7 +260,7 @@ class DateAndOrTime extends Property {
     protected function xmlSerializeValue(Xml\Writer $writer) {
 
         $valueType = strtolower($this->getValueType());
-        $parts     = DateTimeParser::parseVCardDateTime($this->getValue());
+        $parts     = DateTimeParser::parseVCardDateAndOrTime($this->getValue());
         $value     = '';
 
         // $d = defined

--- a/lib/Property/VCard/TimeStamp.php
+++ b/lib/Property/VCard/TimeStamp.php
@@ -4,7 +4,8 @@ namespace Sabre\VObject\Property\VCard;
 
 use
     Sabre\VObject\DateTimeParser,
-    Sabre\VObject\Property\Text;
+    Sabre\VObject\Property\Text,
+    Sabre\Xml;
 
 /**
  * TimeStamp property
@@ -64,6 +65,22 @@ class TimeStamp extends Text {
         }
 
         return [$dateStr];
+
+    }
+
+    /**
+     * This method serializes only the value of a property. This is used to
+     * create xCard or xCal documents.
+     *
+     * @param Xml\Writer $writer  XML writer.
+     * @return void
+     */
+    protected function xmlSerializeValue(Xml\Writer $writer) {
+
+        // xCard is the only XML and JSON format that has the same date and time
+        // format than vCard.
+        $valueType = strtolower($this->getValueType());
+        $writer->writeElement($valueType, $this->getValue());
 
     }
 }

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -19,27 +19,12 @@ class Writer {
     /**
      * Serializes a vCard or iCalendar object.
      *
-     * @param Component|Iterator $component
+     * @param Component $component
      * @return string
      */
-    static function write($component) {
+    static function write(Component $component) {
 
-        if($component instanceof Component) {
-            return $component->serialize();
-        } elseif($component instanceof \Iterator) {
-
-            $out = null;
-            $iterator = $component;
-
-            foreach ($iterator as $component) {
-                $out .= $component->serialize();
-            }
-
-            return $out;
-
-        } else {
-            throw new \InvalidArgumentException('Need a ' . __NAMESPACE__ .  '\Component object or an iterator');
-        }
+        return $component->serialize();
 
     }
 
@@ -59,56 +44,32 @@ class Writer {
     /**
      * Serializes a xCal or xCard object.
      *
-     * @param Component|Iterator $component
+     * @param Component $component
      * @return string
      */
-    static public function writeXml($component) {
+    static public function writeXml(Component $component) {
 
         $writer = new Xml\Writer();
         $writer->openMemory();
         $writer->setIndent(true);
 
-        $startDocument = function($component) use($writer) {
+        $writer->startDocument('1.0', 'utf-8');
 
-            $writer->startDocument('1.0', 'utf-8');
+        if ($component instanceof Component\VCalendar) {
 
-            if ($component instanceof Component\VCalendar) {
-
-                $writer->startElement('icalendar');
-                $writer->writeAttribute('xmlns', Parser\Xml::XCAL_NAMESPACE);
-
-            } else {
-
-                $writer->startElement('vcards');
-                $writer->writeAttribute('xmlns', Parser\Xml::XCARD_NAMESPACE);
-
-            }
-
-        };
-
-        $endDocument = function() use($writer) {
-            $writer->endElement();
-        };
-
-        if($component instanceof Component) {
-
-            $startDocument($component);
-            $component->xmlSerialize($writer);
-            $endDocument();
-
-        } elseif($component instanceof \Iterator) {
-
-            $iterator = $component;
-
-            foreach ($iterator as $component) {
-                $startDocument($component);
-                $component->xmlSerialize($writer);
-                $endDocument();
-            }
+            $writer->startElement('icalendar');
+            $writer->writeAttribute('xmlns', Parser\Xml::XCAL_NAMESPACE);
 
         } else {
-            throw new \InvalidArgumentException('Need a ' . __NAMESPACE__ .  '\Component object or an iterator');
+
+            $writer->startElement('vcards');
+            $writer->writeAttribute('xmlns', Parser\Xml::XCARD_NAMESPACE);
+
         }
+
+        $component->xmlSerialize($writer);
+
+        $writer->endElement();
 
         return $writer->outputMemory();
 

--- a/resources/schema/xcard.rng
+++ b/resources/schema/xcard.rng
@@ -3,6 +3,7 @@
 # Erratum 2994 applied.
 # Erratum 3047 applied.
 # Erratum 3008 applied.
+# Erratum 4247 applied.
 
 default namespace = "urn:ietf:params:xml:ns:vcard-4.0"
 
@@ -28,7 +29,7 @@ value-date = element date {
 
 # 4.3.2
 value-time = element time {
-    xsd:string { pattern = "(\d\d(\d\d(\d\d)?)?|-\d\d(\d\d?)|--\d\d)"
+    xsd:string { pattern = "(\d\d(\d\d(\d\d)?)?|-\d\d(\d\d)?|--\d\d)"
                          ~ "(Z|[+\-]\d\d(\d\d)?)?" }
   }
 

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -509,7 +509,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
 
         /**
          * This is unreachable due to a conflict between date and time pattern.
-         * This is an error in the specification, not in the our implementation.
+         * This is an error in the specification, not in our implementation.
         $this->assertDateAndOrTimeEqualsTo(
             '--01',
             [

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -385,5 +385,275 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testDateAndOrTime_DateWithYearMonthDay() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '20150128',
+            [
+                'year' => '2015',
+                'month' => '01',
+                'date' => '28'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateWithYearMonth() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '2015-01',
+            [
+                'year' => '2015',
+                'month' => '01'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateWithMonth() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '--01',
+            [
+                'month' => '01'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateWithMonthDay() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '--0128',
+            [
+                'month' => '01',
+                'date' => '28'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateWithDay() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28',
+            [
+                'date' => '28'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithHour() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '13',
+            [
+                'hour' => '13'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithHourMinute() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '1353',
+            [
+                'hour' => '13',
+                'minute' => '53'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithHourSecond() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '135301',
+            [
+                'hour' => '13',
+                'minute' => '53',
+                'second' => '01'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithMinute() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '-53',
+            [
+                'minute' => '53'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithMinuteSecond() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '-5301',
+            [
+                'minute' => '53',
+                'second' => '01'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithSecond() {
+
+        $this->assertTrue(true);
+
+        /**
+         * This is unreachable due to a conflict between date and time pattern.
+         * This is an error in the specification, not in the our implementation.
+        $this->assertDateAndOrTimeEqualsTo(
+            '--01',
+            [
+                'second' => '01'
+            ]
+        );
+         */
+
+    }
+
+    function testDateAndOrTime_TimeWithSecondZ() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '--01Z',
+            [
+                'second' => '01',
+                'timezone' => 'Z'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_TimeWithSecondTZ() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '--01+1234',
+            [
+                'second' => '01',
+                'timezone' => '+1234'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithYearMonthDayHour() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '20150128T13',
+            [
+                'year' => '2015',
+                'month' => '01',
+                'date' => '28',
+                'hour' => '13'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithMonthDayHour() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '--0128T13',
+            [
+                'month' => '01',
+                'date' => '28',
+                'hour' => '13'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithDayHour() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28T13',
+            [
+                'date' => '28',
+                'hour' => '13'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithDayHourMinute() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28T1353',
+            [
+                'date' => '28',
+                'hour' => '13',
+                'minute' => '53'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithDayHourMinuteSecond() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28T135301',
+            [
+                'date' => '28',
+                'hour' => '13',
+                'minute' => '53',
+                'second' => '01'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithDayHourZ() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28T13Z',
+            [
+                'date' => '28',
+                'hour' => '13',
+                'timezone' => 'Z'
+            ]
+        );
+
+    }
+
+    function testDateAndOrTime_DateTimeWithDayHourTZ() {
+
+        $this->assertDateAndOrTimeEqualsTo(
+            '---28T13+1234',
+            [
+                'date' => '28',
+                'hour' => '13',
+                'timezone' => '+1234'
+            ]
+        );
+
+    }
+
+    protected function assertDateAndOrTimeEqualsTo($date, $parts) {
+
+        $this->assertSame(
+            DateTimeParser::parseVCardDateAndOrTime($date),
+            array_merge(
+                [
+                    'year' => null,
+                    'month' => null,
+                    'date' => null,
+                    'hour' => null,
+                    'minute' => null,
+                    'second' => null,
+                    'timezone' => null
+                ],
+                $parts
+            )
+        );
+
+    }
 
 }

--- a/tests/VObject/JCardTest.php
+++ b/tests/VObject/JCardTest.php
@@ -92,7 +92,7 @@ class JCardTest extends \PHPUnit_Framework_TestCase {
                     (object)array(
                         "group" => "item1",
                     ),
-                    "uri",
+                    "text",
                     "+1 555 123456",
                 ),
                 array(

--- a/tests/VObject/JCardTest.php
+++ b/tests/VObject/JCardTest.php
@@ -92,7 +92,7 @@ class JCardTest extends \PHPUnit_Framework_TestCase {
                     (object)array(
                         "group" => "item1",
                     ),
-                    "text",
+                    "uri",
                     "+1 555 123456",
                 ),
                 array(

--- a/tests/VObject/Parser/JsonTest.php
+++ b/tests/VObject/Parser/JsonTest.php
@@ -59,7 +59,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
                     (object)array(
                         "group" => "item1",
                     ),
-                    "text",
+                    "uri",
                     "+1 555 123456",
                 ),
                 array(

--- a/tests/VObject/Parser/JsonTest.php
+++ b/tests/VObject/Parser/JsonTest.php
@@ -59,7 +59,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase {
                     (object)array(
                         "group" => "item1",
                     ),
-                    "uri",
+                    "text",
                     "+1 555 123456",
                 ),
                 array(

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1109,6 +1109,9 @@ XML
 
     }
 
+    /**
+     * Basic example.
+     */
     function testRFC6351Basic() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1139,6 +1142,9 @@ XML
 
     }
 
+    /**
+     * Example 1.
+     */
     function testRFC6351Example1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1179,36 +1185,11 @@ XML
             'END:VCARD' . CRLF
         );
 
-        $xml =
-<<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
- <vcard>
-  <fn>
-   <text>J. Doe</text>
-  </fn>
-  <n>
-   <surname>Doe</surname>
-   <given>J.</given>
-   <additional/>
-   <prefix/>
-   <suffix/>
-  </n>
-  <x-file>
-   <parameters>
-    <mediatype>
-     <text>image/jpeg</text>
-    </mediatype>
-   </parameters>
-   <unknown>alien.jpg</unknown>
-  </x-file>
-  <a xmlns="http://www.w3.org/1999/xhtml" href="http://www.example.com">My web page!</a>
- </vcard>
-</vcards>
-XML;
-
     }
 
+    /**
+     * Design Considerations.
+     */
     function testRFC6351Section5() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1237,6 +1218,9 @@ XML
 
     }
 
+    /**
+     * Design Considerations.
+     */
     function testRFC6351Section5Group() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1275,6 +1259,9 @@ XML
 
     }
 
+    /**
+     * Extensibility.
+     */
     function testRFC6351Section5_1_NoNamespace() {
 
         $this->assertXMLEqualsToMimeDir(
@@ -1302,6 +1289,9 @@ XML
 
     }
 
+    /**
+     * Property: SOURCE.
+     */
     function testRFC6350Section6_1_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1324,6 +1314,9 @@ XML
 
     }
 
+    /**
+     * Property: KIND.
+     */
     function testRFC6350Section6_1_4() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1347,6 +1340,9 @@ XML
 
     }
 
+    /**
+     * Property: FN.
+     */
     function testRFC6350Section6_2_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1370,6 +1366,9 @@ XML
 
     }
 
+    /**
+     * Property: N.
+     */
     function testRFC6350Section6_2_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1397,6 +1396,9 @@ XML
 
     }
 
+    /**
+     * Property: NICKNAME.
+     */
     function testRFC6350Section6_2_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1421,6 +1423,9 @@ XML
 
     }
 
+    /**
+     * Property: PHOTO.
+     */
     function testRFC6350Section6_2_4() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1452,6 +1457,9 @@ XML
 
     }
 
+    /**
+     * Property: GENDER.
+     */
     function testRFC6350Section6_2_7() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1476,6 +1484,9 @@ XML
 
     }
 
+    /**
+     * Property: ADR.
+     */
     function testRFC6350Section6_3_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1505,6 +1516,9 @@ XML
 
     }
 
+    /**
+     * Property: TEL.
+     */
     function testRFC6350Section6_4_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1532,6 +1546,9 @@ XML
 
     }
 
+    /**
+     * Property: EMAIL.
+     */
     function testRFC6350Section6_4_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1559,6 +1576,9 @@ XML
 
     }
 
+    /**
+     * Property: IMPP.
+     */
     function testRFC6350Section6_4_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1586,6 +1606,9 @@ XML
 
     }
 
+    /**
+     * Property: LANG.
+     */
     function testRFC6350Section6_4_4() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1616,6 +1639,9 @@ XML
 
     }
 
+    /**
+     * Property: TZ.
+     */
     function testRFC6350Section6_5_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1638,6 +1664,9 @@ XML
 
     }
 
+    /**
+     * Property: GEO.
+     */
     function testRFC6350Section6_5_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1660,6 +1689,9 @@ XML
 
     }
 
+    /**
+     * Property: TITLE.
+     */
     function testRFC6350Section6_6_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1682,6 +1714,9 @@ XML
 
     }
 
+    /**
+     * Property: ROLE.
+     */
     function testRFC6350Section6_6_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1704,6 +1739,9 @@ XML
 
     }
 
+    /**
+     * Property: LOGO.
+     */
     function testRFC6350Section6_6_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1726,6 +1764,9 @@ XML
 
     }
 
+    /**
+     * Property: ORG.
+     */
     function testRFC6350Section6_6_4() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1750,6 +1791,9 @@ XML
 
     }
 
+    /**
+     * Property: MEMBER.
+     */
     function testRFC6350Section6_6_5() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1802,6 +1846,9 @@ XML
 
     }
 
+    /**
+     * Property: RELATED.
+     */
     function testRFC6350Section6_6_6() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1829,6 +1876,9 @@ XML
 
     }
 
+    /**
+     * Property: CATEGORIES.
+     */
     function testRFC6350Section6_7_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1854,6 +1904,9 @@ XML
 
     }
 
+    /**
+     * Property: NOTE.
+     */
     function testRFC6350Section6_7_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1876,6 +1929,9 @@ XML
 
     }
 
+    /**
+     * Property: PRODID.
+     */
     function testRFC6350Section6_7_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1898,6 +1954,9 @@ XML
 
     }
 
+    /**
+     * Property: SOUND.
+     */
     function testRFC6350Section6_7_5() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1920,6 +1979,9 @@ XML
 
     }
 
+    /**
+     * Property: UID.
+     */
     function testRFC6350Section6_7_6() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1942,6 +2004,9 @@ XML
 
     }
 
+    /**
+     * Property: CLIENTPIDMAP.
+     */
     function testRFC6350Section6_7_7() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1965,6 +2030,9 @@ XML
 
     }
 
+    /**
+     * Property: URL.
+     */
     function testRFC6350Section6_7_8() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -1987,6 +2055,9 @@ XML
 
     }
 
+    /**
+     * Property: VERSION.
+     */
     function testRFC6350Section6_7_9() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -2004,6 +2075,9 @@ XML
 
     }
 
+    /**
+     * Property: KEY.
+     */
     function testRFC6350Section6_8_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -2031,6 +2105,9 @@ XML
 
     }
 
+    /**
+     * Property: FBURL.
+     */
     function testRFC6350Section6_9_1() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -2058,6 +2135,9 @@ XML
 
     }
 
+    /**
+     * Property: CALADRURI.
+     */
     function testRFC6350Section6_9_2() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -2080,6 +2160,9 @@ XML
 
     }
 
+    /**
+     * Property: CALURI.
+     */
     function testRFC6350Section6_9_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(
@@ -2107,6 +2190,9 @@ XML
 
     }
 
+    /**
+     * Property: CAPURI.
+     */
     function testRFC6350SectionA_3() {
 
         $this->assertXMLReflexivelyEqualsToMimeDir(

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1331,7 +1331,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'KIND:individual' . CRLF .
@@ -1357,7 +1356,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'FN:Mr. John Q. Public\, Esq.' . CRLF .
@@ -1387,7 +1385,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'N:Stevenson;John;Philip\,Paul;Dr.;Jr.\,M.D.\,A.C.P.' . CRLF .
@@ -1414,7 +1411,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'NICKNAME:Jim,Jimmie' . CRLF .
@@ -1440,7 +1436,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'PHOTO:http://www.example.com/pub/photos/jqpublic.gif' . CRLF .
@@ -1463,7 +1458,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'BDAY:19531015T231000Z' . CRLF .
@@ -1486,7 +1480,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'ANNIVERSARY:19960415' . CRLF .
@@ -1513,7 +1506,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'GENDER:Jim;Jimmie' . CRLF .
@@ -1545,7 +1537,6 @@ XML
 </vcards>
 XML
 ,
-
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.A.' . CRLF .

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1179,6 +1179,40 @@ XML
 
     }
 
+    function testRFC6351Section5Group() {
+
+        $this->assertXMLEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <group name="contact">
+   <fn>
+    <text>Gordon</text>
+   </fn>
+  </group>
+  <group name="media">
+   <fn>
+    <text>Gordon</text>
+   </fn>
+  </group>
+  <tel>
+   <uri>tel:+1-555-555-555</uri>
+  </tel>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'contact.FN:Gordon' . CRLF .
+            'media.FN:Gordon' . CRLF .
+            'TEL:tel:+1-555-555-555' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1290,6 +1290,515 @@ XML
     }
 
     /**
+     * Section 4.3.1 of Relax NG Schema: value-date.
+     */
+    function testRFC6351ValueDateWithYearMonthDay() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>20150128</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:20150128' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.1 of Relax NG Schema: value-date.
+     */
+    function testRFC6351ValueDateWithYearMonth() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>2015-01</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:2015-01' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.1 of Relax NG Schema: value-date.
+     */
+    function testRFC6351ValueDateWithMonth() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--01</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--01' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.1 of Relax NG Schema: value-date.
+     */
+    function testRFC6351ValueDateWithMonthDay() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--0128</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--0128' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.1 of Relax NG Schema: value-date.
+     */
+    function testRFC6351ValueDateWithDay() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithHour() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>13</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:13' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithHourMinute() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>1353</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:1353' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithHourMinuteSecond() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>135301</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:135301' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithMinute() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>-53</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:-53' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithMinuteSecond() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>-5301</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:-5301' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithSecond() {
+
+        $this->assertTrue(true);
+
+        /*
+         * According to the Relax NG Schema, there is a conflict between
+         * value-date and value-time. The --01 syntax can only match a
+         * value-date because of the higher priority set in
+         * value-date-and-or-time. So we basically skip this test.
+         *
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--01</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--01' . CRLF .
+            'END:VCARD' . CRLF
+        );
+        */
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithSecondZ() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--01Z</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--01Z' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.2 of Relax NG Schema: value-time.
+     */
+    function testRFC6351ValueTimeWithSecondTZ() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--01+1234</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--01+1234' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithYearMonthDayHour() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>20150128T13</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:20150128T13' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithMonthDayHour() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>--0128T13</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:--0128T13' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithDayHour() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28T13</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28T13' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithDayHourMinute() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28T1353</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28T1353' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithDayHourMinuteSecond() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28T135301</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28T135301' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithDayHourZ() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28T13Z</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28T13Z' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
+     * Section 4.3.3 of Relax NG Schema: value-date-time.
+     */
+    function testRFC6351ValueDateTimeWithDayHourTZ() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>---28T13+1234</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:---28T13+1234' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    /**
      * Property: SOURCE.
      */
     function testRFC6350Section6_1_3() {

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2004,6 +2004,32 @@ XML
 
     }
 
+    function testRFC6350Section6_8_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <key>
+   <parameters>
+    <mediatype>
+     <text>application/pgp-keys</text>
+    </mediatype>
+   </parameters>
+   <text>ftp://example.com/keys/jdoe</text>
+  </key>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'KEY;MEDIATYPE=application/pgp-keys:ftp://example.com/keys/jdoe' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1253,14 +1253,14 @@ XML
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
  <vcard>
   <tel>
-   <uri>tel:+1-555-555-556</uri>
+   <text>tel:+1-555-555-556</text>
   </tel>
   <group name="contact">
    <fn>
     <text>Gordon</text>
    </fn>
    <tel>
-    <uri>tel:+1-555-555-555</uri>
+    <text>tel:+1-555-555-555</text>
    </tel>
   </group>
   <group name="media">
@@ -2264,13 +2264,31 @@ XML
      */
     function testRFC6350Section6_5_2() {
 
-        $this->assertXMLReflexivelyEqualsToMimeDir(
+        $this->assertXMLEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
  <vcard>
   <geo>
    <uri>geo:37.386013,-122.082932</uri>
+  </geo>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'GEO:geo:37.386013\,-122.082932' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <geo>
+   <text>geo:37.386013,-122.082932</text>
   </geo>
  </vcard>
 </vcards>

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1954,6 +1954,28 @@ XML
 
     }
 
+    function testRFC6350Section6_7_4() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <rev>
+   <timestamp>19951031T222710Z</timestamp>
+  </rev>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'REV:19951031T222710Z' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Property: SOUND.
      */

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1302,6 +1302,180 @@ XML
 
     }
 
+    function testRFC6350Section6_1_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <source>
+   <uri>ldap://ldap.example.com/cn=Babs%20Jensen,%20o=Babsco,%20c=US</uri>
+  </source>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'SOURCE:ldap://ldap.example.com/cn=Babs%20Jensen,%20o=Babsco,%20c=US' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_1_4() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <kind>
+   <text>individual</text>
+  </kind>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'KIND:individual' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_2_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <fn>
+   <text>Mr. John Q. Public, Esq.</text>
+  </fn>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'FN:Mr. John Q. Public\, Esq.' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_2_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <n>
+   <surname>Stevenson</surname>
+   <given>John</given>
+   <additional>Philip,Paul</additional>
+   <prefix>Dr.</prefix>
+   <suffix>Jr.,M.D.,A.C.P.</suffix>
+  </n>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'N:Stevenson;John;Philip\,Paul;Dr.;Jr.\,M.D.\,A.C.P.' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_2_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <nickname>
+   <text>Jim</text>
+   <text>Jimmie</text>
+  </nickname>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'NICKNAME:Jim,Jimmie' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_2_4() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <photo>
+   <uri>http://www.example.com/pub/photos/jqpublic.gif</uri>
+  </photo>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'PHOTO:http://www.example.com/pub/photos/jqpublic.gif' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_2_5() {
+
+    }
+
+    function testRFC6350Section6_2_6() {
+
+    }
+
+    function testRFC6350Section6_2_7() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <gender>
+   <sex>Jim</sex>
+   <text>Jimmie</text>
+  </gender>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'GENDER:Jim;Jimmie' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1109,6 +1109,28 @@ XML
 
     }
 
+    function testRFC6351Basic() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <fn>
+   <text>J. Doe</text>
+  </fn>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'FN:J. Doe' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     function testRFC6351Example1() {
 
         $this->assertXMLEqualsToMimeDir(

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1318,7 +1318,7 @@ XML
 ,
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
-            'SOURCE:ldap://ldap.example.com/cn=Babs%20Jensen,%20o=Babsco,%20c=US' . CRLF .
+            'SOURCE:ldap://ldap.example.com/cn=Babs%20Jensen\,%20o=Babsco\,%20c=US' . CRLF .
             'END:VCARD' . CRLF
         );
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1616,6 +1616,50 @@ XML
 
     }
 
+    function testRFC6350Section6_5_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <tz>
+   <text>Raleigh/North America</text>
+  </tz>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TZ:Raleigh/North America' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_5_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <geo>
+   <uri>geo:37.386013,-122.082932</uri>
+  </geo>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'GEO:geo:37.386013\,-122.082932' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2594,13 +2594,31 @@ XML
      */
     function testRFC6350Section6_7_5() {
 
-        $this->assertXMLReflexivelyEqualsToMimeDir(
+        $this->assertXMLEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
  <vcard>
   <sound>
    <uri>CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com</uri>
+  </sound>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'SOUND:CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <sound>
+   <text>CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com</text>
   </sound>
  </vcard>
 </vcards>

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1151,37 +1151,6 @@ XML
 
     }
 
-    function testRFC6351MultipleVCard() {
-
-        $this->assertXMLEqualsToMimeDir(
-<<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
- <vcard>
-  <fn>
-   <text>J. Doe</text>
-  </fn>
- </vcard>
- <vcard>
-  <fn>
-   <text>G. Freeman</text>
-  </fn>
- </vcard>
-</vcards>
-XML
-,
-            'BEGIN:VCARD' . CRLF .
-            'VERSION:4.0' . CRLF .
-            'FN:J. Doe' . CRLF .
-            'END:VCARD' . CRLF .
-            'BEGIN:VCARD' . CRLF .
-            'VERSION:4.0' . CRLF .
-            'FN:G. Freeman' . CRLF .
-            'END:VCARD' . CRLF
-        );
-
-    }
-
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1213,6 +1213,33 @@ XML
 
     }
 
+    function testRFC6351Section5_1_NoNamespace() {
+
+        $this->assertXMLEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <x-my-prop>
+   <parameters>
+    <pref>
+     <integer>1</integer>
+    </pref>
+   </parameters>
+   <text>value goes here</text>
+  </x-my-prop>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'X-MY-PROP;PREF=1:value goes here' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1211,7 +1211,7 @@ XML;
 
     function testRFC6351Section5() {
 
-        $this->assertXMLEqualsToMimeDir(
+        $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
@@ -1239,33 +1239,37 @@ XML
 
     function testRFC6351Section5Group() {
 
-        $this->assertXMLEqualsToMimeDir(
+        $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
  <vcard>
+  <tel>
+   <uri>tel:+1-555-555-556</uri>
+  </tel>
   <group name="contact">
    <fn>
     <text>Gordon</text>
    </fn>
+   <tel>
+    <uri>tel:+1-555-555-555</uri>
+   </tel>
   </group>
   <group name="media">
    <fn>
     <text>Gordon</text>
    </fn>
   </group>
-  <tel>
-   <uri>tel:+1-555-555-555</uri>
-  </tel>
  </vcard>
 </vcards>
 XML
 ,
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
+            'TEL:tel:+1-555-555-556' . CRLF .
             'contact.FN:Gordon' . CRLF .
+            'contact.TEL:tel:+1-555-555-555' . CRLF .
             'media.FN:Gordon' . CRLF .
-            'TEL:tel:+1-555-555-555' . CRLF .
             'END:VCARD' . CRLF
         );
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1119,6 +1119,13 @@ XML
   <fn>
    <text>J. Doe</text>
   </fn>
+  <n>
+   <surname>Doe</surname>
+   <given>J.</given>
+   <additional/>
+   <prefix/>
+   <suffix/>
+  </n>
  </vcard>
 </vcards>
 XML
@@ -1126,6 +1133,7 @@ XML
             'BEGIN:VCARD' . CRLF .
             'VERSION:4.0' . CRLF .
             'FN:J. Doe' . CRLF .
+            'N:Doe;J.;;;' . CRLF .
             'END:VCARD' . CRLF
         );
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1170,7 +1170,7 @@ XML
    </parameters>
    <unknown>alien.jpg</unknown>
   </x-file>
-  <a xmlns="http://www.w3.org/1999/xhtml" href="http://www.example.com">My web page!</a>
+  <x1:a href="http://www.example.com" xmlns:x1="http://www.w3.org/1999/xhtml">My web page!</x1:a>
  </vcard>
 </vcards>
 XML

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1151,6 +1151,34 @@ XML
 
     }
 
+    function testRFC6351Section5() {
+
+        $this->assertXMLEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <tel>
+   <parameters>
+    <type>
+     <text>voice</text>
+     <text>video</text>
+    </type>
+   </parameters>
+   <uri>tel:+1-555-555-555</uri>
+  </tel>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TEL;TYPE="voice,video":tel:+1-555-555-555' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1660,6 +1660,175 @@ XML
 
     }
 
+    function testRFC6350Section6_6_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <title>
+   <text>Research Scientist</text>
+  </title>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TITLE:Research Scientist' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_6_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <role>
+   <text>Project Leader</text>
+  </role>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'ROLE:Project Leader' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_6_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <logo>
+   <uri>http://www.example.com/pub/logos/abccorp.jpg</uri>
+  </logo>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'LOGO:http://www.example.com/pub/logos/abccorp.jpg' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_6_4() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <org>
+   <text>ABC, Inc.</text>
+   <text>North American Division</text>
+   <text>Marketing</text>
+  </org>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'ORG:ABC\, Inc.;North American Division;Marketing' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_6_5() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <member>
+   <uri>urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af</uri>
+  </member>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'MEMBER:urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <member>
+   <uri>mailto:subscriber1@example.com</uri>
+  </member>
+  <member>
+   <uri>xmpp:subscriber2@example.com</uri>
+  </member>
+  <member>
+   <uri>sip:subscriber3@example.com</uri>
+  </member>
+  <member>
+   <uri>tel:+1-418-555-5555</uri>
+  </member>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'MEMBER:mailto:subscriber1@example.com' . CRLF .
+            'MEMBER:xmpp:subscriber2@example.com' . CRLF .
+            'MEMBER:sip:subscriber3@example.com' . CRLF .
+            'MEMBER:tel:+1-418-555-5555' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_6_6() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <related>
+   <parameters>
+    <type>
+     <text>friend</text>
+    </type>
+   </parameters>
+   <uri>urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6</uri>
+  </related>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'RELATED;TYPE=friend:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -2030,6 +2030,105 @@ XML
         );
 
     }
+
+    function testRFC6350Section6_9_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <fburl>
+   <parameters>
+    <pref>
+     <text>1</text>
+    </pref>
+   </parameters>
+   <uri>http://www.example.com/busy/janedoe</uri>
+  </fburl>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'FBURL;PREF=1:http://www.example.com/busy/janedoe' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_9_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <caladruri>
+   <uri>http://example.com/calendar/jdoe</uri>
+  </caladruri>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'CALADRURI:http://example.com/calendar/jdoe' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_9_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <caluri>
+   <parameters>
+    <pref>
+     <text>1</text>
+    </pref>
+   </parameters>
+   <uri>http://cal.example.com/calA</uri>
+  </caluri>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'CALURI;PREF=1:http://cal.example.com/calA' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350SectionA_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <capuri>
+   <uri>http://cap.example.com/capA</uri>
+  </capuri>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'CAPURI:http://cap.example.com/capA' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1451,9 +1451,47 @@ XML
 
     function testRFC6350Section6_2_5() {
 
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <bday>
+   <date-and-or-time>19531015T231000Z</date-and-or-time>
+  </bday>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'BDAY:19531015T231000Z' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
     }
 
     function testRFC6350Section6_2_6() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <anniversary>
+   <date-and-or-time>19960415</date-and-or-time>
+  </anniversary>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'ANNIVERSARY:19960415' . CRLF .
+            'END:VCARD' . CRLF
+        );
 
     }
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1505,6 +1505,117 @@ XML
 
     }
 
+    function testRFC6350Section6_4_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <tel>
+   <parameters>
+    <type>
+     <text>home</text>
+    </type>
+   </parameters>
+   <uri>tel:+33-01-23-45-67</uri>
+  </tel>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TEL;TYPE=home:tel:+33-01-23-45-67' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_4_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <email>
+   <parameters>
+    <type>
+     <text>work</text>
+    </type>
+   </parameters>
+   <text>jqpublic@xyz.example.com</text>
+  </email>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'EMAIL;TYPE=work:jqpublic@xyz.example.com' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_4_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <impp>
+   <parameters>
+    <pref>
+     <text>1</text>
+    </pref>
+   </parameters>
+   <uri>xmpp:alice@example.com</uri>
+  </impp>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'IMPP;PREF=1:xmpp:alice@example.com' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_4_4() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <lang>
+   <parameters>
+    <type>
+     <text>work</text>
+    </type>
+    <pref>
+     <text>2</text>
+    </pref>
+   </parameters>
+   <language-tag>en</language-tag>
+  </lang>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'LANG;TYPE=work;PREF=2:en' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1192,7 +1192,7 @@ XML
      */
     function testRFC6351Section5() {
 
-        $this->assertXMLReflexivelyEqualsToMimeDir(
+        $this->assertXMLEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
@@ -1205,6 +1205,30 @@ XML
     </type>
    </parameters>
    <uri>tel:+1-555-555-555</uri>
+  </tel>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TEL;TYPE="voice,video":tel:+1-555-555-555' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <tel>
+   <parameters>
+    <type>
+     <text>voice</text>
+     <text>video</text>
+    </type>
+   </parameters>
+   <text>tel:+1-555-555-555</text>
   </tel>
  </vcard>
 </vcards>
@@ -2059,7 +2083,17 @@ XML
      */
     function testRFC6350Section6_4_1() {
 
-        $this->assertXMLReflexivelyEqualsToMimeDir(
+        /**
+         * Quoting RFC:
+         * > Value type:  By default, it is a single free-form text value (for
+         * > backward compatibility with vCard 3), but it SHOULD be reset to a
+         * > URI value.  It is expected that the URI scheme will be "tel", as
+         * > specified in [RFC3966], but other schemes MAY be used.
+         *
+         * So first, we test xCard/URI to vCard/URI.
+         * Then, we test xCard/TEXT to vCard/TEXT to xCard/TEXT.
+         */
+        $this->assertXMLEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
@@ -2071,6 +2105,29 @@ XML
     </type>
    </parameters>
    <uri>tel:+33-01-23-45-67</uri>
+  </tel>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'TEL;TYPE=home:tel:+33-01-23-45-67' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <tel>
+   <parameters>
+    <type>
+     <text>home</text>
+    </type>
+   </parameters>
+   <text>tel:+33-01-23-45-67</text>
   </tel>
  </vcard>
 </vcards>

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1829,6 +1829,181 @@ XML
 
     }
 
+    function testRFC6350Section6_7_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <categories>
+   <text>INTERNET</text>
+   <text>IETF</text>
+   <text>INDUSTRY</text>
+   <text>INFORMATION TECHNOLOGY</text>
+  </categories>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'CATEGORIES:INTERNET,IETF,INDUSTRY,INFORMATION TECHNOLOGY' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_2() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <note>
+   <text>Foo, bar</text>
+  </note>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'NOTE:Foo\, bar' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_3() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <prodid>
+   <text>-//ONLINE DIRECTORY//NONSGML Version 1//EN</text>
+  </prodid>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'PRODID:-//ONLINE DIRECTORY//NONSGML Version 1//EN' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_5() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <sound>
+   <uri>CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com</uri>
+  </sound>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'SOUND:CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_6() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <uid>
+   <text>urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6</text>
+  </uid>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'UID:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_7() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <clientpidmap>
+   <sourceid>1</sourceid>
+   <uri>urn:uuid:3df403f4-5924-4bb7-b077-3c711d9eb34b</uri>
+  </clientpidmap>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'CLIENTPIDMAP:1;urn:uuid:3df403f4-5924-4bb7-b077-3c711d9eb34b' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_8() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <url>
+   <uri>http://example.org/restaurant.french/~chezchic.html</uri>
+  </url>
+ </vcard>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'URL:http://example.org/restaurant.french/~chezchic.html' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
+    function testRFC6350Section6_7_9() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard/>
+</vcards>
+XML
+,
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1141,7 +1141,7 @@ XML
 
     function testRFC6351Example1() {
 
-        $this->assertXMLEqualsToMimeDir(
+        $this->assertXMLReflexivelyEqualsToMimeDir(
 <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
@@ -1178,6 +1178,34 @@ XML
             ' y web page!</a>' . CRLF .
             'END:VCARD' . CRLF
         );
+
+        $xml =
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <fn>
+   <text>J. Doe</text>
+  </fn>
+  <n>
+   <surname>Doe</surname>
+   <given>J.</given>
+   <additional/>
+   <prefix/>
+   <suffix/>
+  </n>
+  <x-file>
+   <parameters>
+    <mediatype>
+     <text>image/jpeg</text>
+    </mediatype>
+   </parameters>
+   <unknown>alien.jpg</unknown>
+  </x-file>
+  <a xmlns="http://www.w3.org/1999/xhtml" href="http://www.example.com">My web page!</a>
+ </vcard>
+</vcards>
+XML;
 
     }
 

--- a/tests/VObject/Parser/XmlTest.php
+++ b/tests/VObject/Parser/XmlTest.php
@@ -1476,6 +1476,35 @@ XML
 
     }
 
+    function testRFC6350Section6_3_1() {
+
+        $this->assertXMLReflexivelyEqualsToMimeDir(
+<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<vcards xmlns="urn:ietf:params:xml:ns:vcard-4.0">
+ <vcard>
+  <adr>
+   <pobox/>
+   <ext/>
+   <street>123 Main Street</street>
+   <locality>Any Town</locality>
+   <region>CA</region>
+   <code>91921-1234</code>
+   <country>U.S.A.</country>
+  </adr>
+ </vcard>
+</vcards>
+XML
+,
+
+            'BEGIN:VCARD' . CRLF .
+            'VERSION:4.0' . CRLF .
+            'ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.A.' . CRLF .
+            'END:VCARD' . CRLF
+        );
+
+    }
+
     /**
      * Check this equality:
      *     XML -> object model -> MIME Dir.

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -458,7 +458,7 @@ ICS;
 </icalendar>
 XML;
 
-        $result = Reader::readXML($data)->current();
+        $result = Reader::readXML($data);
 
         $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
         $this->assertEquals('VCALENDAR', $result->name);
@@ -480,7 +480,7 @@ XML;
         fwrite($stream, $data);
         rewind($stream);
 
-        $result = Reader::readXML($stream)->current();
+        $result = Reader::readXML($stream);
 
         $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
         $this->assertEquals('VCALENDAR', $result->name);

--- a/tests/VObject/ReaderTest.php
+++ b/tests/VObject/ReaderTest.php
@@ -458,7 +458,7 @@ ICS;
 </icalendar>
 XML;
 
-        $result = Reader::readXML($data);
+        $result = Reader::readXML($data)->current();
 
         $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
         $this->assertEquals('VCALENDAR', $result->name);
@@ -480,7 +480,7 @@ XML;
         fwrite($stream, $data);
         rewind($stream);
 
-        $result = Reader::readXML($stream);
+        $result = Reader::readXML($stream)->current();
 
         $this->assertInstanceOf('Sabre\\VObject\\Component', $result);
         $this->assertEquals('VCALENDAR', $result->name);

--- a/tests/VObject/WriterTest.php
+++ b/tests/VObject/WriterTest.php
@@ -18,33 +18,6 @@ class WriterTest extends \PHPUnit_Framework_TestCase {
 
     }
 
-    function testWriteToMimeDirWithIterator() {
-
-        $iterator = function() {
-            for($i = 0; $i < 3; ++$i) {
-                yield $this->getComponent();
-            }
-        };
-
-        $result = Writer::write($iterator());
-        $this->assertEquals(
-            "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" .
-            "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" .
-            "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n",
-            $result
-        );
-
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    function testWriteToMimeDirWithUnexpectedArgument() {
-
-        $result = Writer::write('foo');
-
-    }
-
     function testWriteToJson() {
 
         $result = Writer::writeJson($this->getComponent());
@@ -62,15 +35,6 @@ class WriterTest extends \PHPUnit_Framework_TestCase {
             '</icalendar>' . "\n",
             $result
         );
-
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    function testWriteToXmlWithUnexpectedArgument() {
-
-        $result = Writer::writeXml('foo');
 
     }
 


### PR DESCRIPTION
Fix #167.

[RFC6351](https://tools.ietf.org/html/rfc6351):

  * [x] write the schema,
  * [x] read:
    * [x] example 1 must pass,
    * [x] extensibility must be supported,
    * [x] assume we parse only one vCard at a time,
    * [x] support parameter with multiple values,
    * [x] support groups.
  * [x] write:
    * [x] example 1 must pass,
    * [x] extensibility must be supported,
    * [x] support parameter with multiple values,
    * [x] support groups,
  * [x] tests,
  * [x] no more unsolved comments.