### PR TITLE
LAST-MODIFICATION does not exist: It's LAST-MODIFIED.

### DIFF
--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -108,7 +108,7 @@ class VEvent extends VObject\Component {
             'CREATED' => '?',
             'DESCRIPTION' => '?',
             'GEO' => '?',
-            'LAST-MODIFICATION' => '?',
+            'LAST-MODIFIED' => '?',
             'LOCATION' => '?',
             'ORGANIZER' => '?',
             'PRIORITY' => '?',

--- a/lib/Component/VJournal.php
+++ b/lib/Component/VJournal.php
@@ -66,7 +66,7 @@ class VJournal extends VObject\Component {
             'CLASS' => '?',
             'CREATED' => '?',
             'DTSTART' => '?',
-            'LAST-MODIFICATION' => '?',
+            'LAST-MODIFIED' => '?',
             'ORGANIZER' => '?',
             'RECURRENCE-ID' => '?',
             'SEQUENCE' => '?',

--- a/lib/Component/VTimeZone.php
+++ b/lib/Component/VTimeZone.php
@@ -49,7 +49,7 @@ class VTimeZone extends VObject\Component {
         return [
             'TZID' => 1,
 
-            'LAST-MODIFICATION' => '?',
+            'LAST-MODIFIED' => '?',
             'TZURL' => '?',
 
             // At least 1 STANDARD or DAYLIGHT must appear, or more. But both

--- a/lib/Component/VTodo.php
+++ b/lib/Component/VTodo.php
@@ -91,7 +91,7 @@ class VTodo extends VObject\Component {
             'DESCRIPTION' => '?',
             'DTSTART' => '?',
             'GEO' => '?',
-            'LAST-MODIFICATION' => '?',
+            'LAST-MODIFIED' => '?',
             'LOCATION' => '?',
             'ORGANIZER' => '?',
             'PERCENT' => '?',


### PR DESCRIPTION
According to [RFC5545](https://tools.ietf.org/html/rfc5545#section-3.8.7.3), there is no `LAST-MODIFICATION` property, only `LAST-MODIFIED`. This patch fixes this bug. No test is added.