### PR TITLE
Support VAVAILABILITY, parsing

### DIFF
--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -33,7 +33,7 @@ class Available extends VObject\Component {
      */
     function getValidationRules() {
 
-        return [
+        return array(
             'UID' => 1,
             'DTSTART' => 1,
             'DTSTAMP' => 1,
@@ -55,7 +55,7 @@ class Available extends VObject\Component {
             'RDATE' => '*',
 
             'AVAILABLE' => '*',
-        ];
+        );
 
     }
 

--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sabre\VObject\Component;
+
+use Sabre\VObject;
+
+/**
+ * The Available sub-component
+ *
+ * This component adds functionality to a component, specific for AVAILABLE
+ * components.
+ *
+ * @copyright Copyright (C) 2011-2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class Available extends VObject\Component {
+
+}

--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -87,19 +87,19 @@ class Available extends VObject\Component {
         $result = parent::validate($options);
 
         if (isset($this->DTEND) && isset($this->DURATION)) {
-            $result[] = [
+            $result[] = array(
                 'level' => 3,
                 'message' => 'DTEND and DURATION cannot both be present',
                 'node' => $this
-            ];
+            );
         }
 
         if (isset($this->DURATION) && !isset($this->DTSTART)) {
-            $result[] = [
+            $result[] = array(
                 'level' => 3,
                 'message' => 'DURATION must be declared with a DTSTART.',
                 'node' => $this
-            ];
+            );
         }
 
         return $result;

--- a/lib/Component/Available.php
+++ b/lib/Component/Available.php
@@ -16,4 +16,93 @@ use Sabre\VObject;
  */
 class Available extends VObject\Component {
 
+    /**
+     * A simple list of validation rules.
+     *
+     * This is simply a list of properties, and how many times they either
+     * must or must not appear.
+     *
+     * Possible values per property:
+     *   * 0 - Must not appear.
+     *   * 1 - Must appear exactly once.
+     *   * + - Must appear at least once.
+     *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
+     *
+     * @var array
+     */
+    function getValidationRules() {
+
+        return [
+            'UID' => 1,
+            'DTSTART' => 1,
+            'DTSTAMP' => 1,
+
+            'DTEND' => '?',
+            'DURATION' => '?',
+
+            'CREATED' => '?',
+            'DESCRIPTION' => '?',
+            'LAST-MODIFIED' => '?',
+            'RECURRENCE-ID' => '?',
+            'RRULE' => '?',
+            'SUMMARY' => '?',
+
+            'CATEGORIES' => '*',
+            'COMMENT' => '*',
+            'CONTACT' => '*',
+            'EXDATE' => '*',
+            'RDATE' => '*',
+
+            'AVAILABLE' => '*',
+        ];
+
+    }
+
+    /**
+     * Validates the node for correctness.
+     *
+     * The following options are supported:
+     *   Node::REPAIR - May attempt to automatically repair the problem.
+     *   Node::PROFILE_CARDDAV - Validate the vCard for CardDAV purposes.
+     *   Node::PROFILE_CALDAV - Validate the iCalendar for CalDAV purposes.
+     *
+     * This method returns an array with detected problems.
+     * Every element has the following properties:
+     *
+     *  * level - problem level.
+     *  * message - A human-readable string describing the issue.
+     *  * node - A reference to the problematic node.
+     *
+     * The level means:
+     *   1 - The issue was repaired (only happens if REPAIR was turned on).
+     *   2 - A warning.
+     *   3 - An error.
+     *
+     * @param int $options
+     * @return array
+     */
+    function validate($options = 0) {
+
+        $result = parent::validate($options);
+
+        if (isset($this->DTEND) && isset($this->DURATION)) {
+            $result[] = [
+                'level' => 3,
+                'message' => 'DTEND and DURATION cannot both be present',
+                'node' => $this
+            ];
+        }
+
+        if (isset($this->DURATION) && !isset($this->DTSTART)) {
+            $result[] = [
+                'level' => 3,
+                'message' => 'DURATION must be declared with a DTSTART.',
+                'node' => $this
+            ];
+        }
+
+        return $result;
+
+    }
 }

--- a/lib/Component/VAlarm.php
+++ b/lib/Component/VAlarm.php
@@ -116,6 +116,7 @@ class VAlarm extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -16,4 +16,45 @@ use Sabre\VObject;
  */
 class VAvailability extends VObject\Component {
 
+    /**
+     * A simple list of validation rules.
+     *
+     * This is simply a list of properties, and how many times they either
+     * must or must not appear.
+     *
+     * Possible values per property:
+     *   * 0 - Must not appear.
+     *   * 1 - Must appear exactly once.
+     *   * + - Must appear at least once.
+     *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
+     *
+     * @var array
+     */
+    function getValidationRules() {
+
+        return [
+            'UID' => 1,
+            'DTSTAMP' => 1,
+
+            'BUSYTYPE' => '?',
+            'CLASS' => '?',
+            'CREATED' => '?',
+            'DESCRIPTION' => '?',
+            'DTSTART' => '?',
+            'LAST-MODIFIED' => '?',
+            'ORGANIZER' => '?',
+            'PRIORITY' => '?',
+            'SEQUENCE' => '?',
+            'SUMMARY' => '?',
+            'URL' => '?',
+            'DTEND' => '?',
+            'DURATION' => '?',
+
+            'CATEGORIES' => '*',
+            'COMMENT' => '*',
+            'CONTACT' => '*',
+        ];
+
+    }
 }

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -54,6 +54,8 @@ class VAvailability extends VObject\Component {
             'CATEGORIES' => '*',
             'COMMENT' => '*',
             'CONTACT' => '*',
+
+            'AVAILABLE' => '*',
         ];
 
     }

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -57,4 +57,43 @@ class VAvailability extends VObject\Component {
         ];
 
     }
+
+    /**
+     * Validates the node for correctness.
+     *
+     * The following options are supported:
+     *   Node::REPAIR - May attempt to automatically repair the problem.
+     *   Node::PROFILE_CARDDAV - Validate the vCard for CardDAV purposes.
+     *   Node::PROFILE_CALDAV - Validate the iCalendar for CalDAV purposes.
+     *
+     * This method returns an array with detected problems.
+     * Every element has the following properties:
+     *
+     *  * level - problem level.
+     *  * message - A human-readable string describing the issue.
+     *  * node - A reference to the problematic node.
+     *
+     * The level means:
+     *   1 - The issue was repaired (only happens if REPAIR was turned on).
+     *   2 - A warning.
+     *   3 - An error.
+     *
+     * @param int $options
+     * @return array
+     */
+    function validate($options = 0) {
+
+        $result = parent::validate($options);
+
+        if (isset($this->DTEND) && isset($this->DURATION)) {
+            $result[] = [
+                'level' => 3,
+                'message' => 'DTEND and DURATION cannot both be present',
+                'node' => $this
+            ];
+        }
+
+        return $result;
+
+    }
 }

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sabre\VObject\Component;
+
+use Sabre\VObject;
+
+/**
+ * The VAvailability component
+ *
+ * This component adds functionality to a component, specific for VAVAILABILITY
+ * components.
+ *
+ * @copyright Copyright (C) 2011-2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class VAvailability extends VObject\Component {
+
+}

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -86,11 +86,11 @@ class VAvailability extends VObject\Component {
         $result = parent::validate($options);
 
         if (isset($this->DTEND) && isset($this->DURATION)) {
-            $result[] = [
+            $result[] = array(
                 'level' => 3,
                 'message' => 'DTEND and DURATION cannot both be present',
                 'node' => $this
-            ];
+            );
         }
 
         return $result;

--- a/lib/Component/VAvailability.php
+++ b/lib/Component/VAvailability.php
@@ -33,7 +33,7 @@ class VAvailability extends VObject\Component {
      */
     function getValidationRules() {
 
-        return [
+        return array(
             'UID' => 1,
             'DTSTAMP' => 1,
 
@@ -54,9 +54,7 @@ class VAvailability extends VObject\Component {
             'CATEGORIES' => '*',
             'COMMENT' => '*',
             'CONTACT' => '*',
-
-            'AVAILABLE' => '*',
-        ];
+        );
 
     }
 

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -39,6 +39,7 @@ class VCalendar extends VObject\Document {
         'VEVENT'        => 'Sabre\\VObject\\Component\\VEvent',
         'VFREEBUSY'     => 'Sabre\\VObject\\Component\\VFreeBusy',
         'VAVAILABILITY' => 'Sabre\\VObject\\Component\\VAvailability',
+        'AVAILABLE'     => 'Sabre\\VObject\\Component\\Available',
         'VJOURNAL'      => 'Sabre\\VObject\\Component\\VJournal',
         'VTIMEZONE'     => 'Sabre\\VObject\\Component\\VTimeZone',
         'VTODO'         => 'Sabre\\VObject\\Component\\VTodo',

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -353,6 +353,7 @@ class VCalendar extends VObject\Document {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -487,4 +487,3 @@ class VCalendar extends VObject\Document {
     }
 
 }
-

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -35,12 +35,13 @@ class VCalendar extends VObject\Document {
      * @var array
      */
     static $componentMap = array(
-        'VALARM'    => 'Sabre\\VObject\\Component\\VAlarm',
-        'VEVENT'    => 'Sabre\\VObject\\Component\\VEvent',
-        'VFREEBUSY' => 'Sabre\\VObject\\Component\\VFreeBusy',
-        'VJOURNAL'  => 'Sabre\\VObject\\Component\\VJournal',
-        'VTIMEZONE' => 'Sabre\\VObject\\Component\\VTimeZone',
-        'VTODO'     => 'Sabre\\VObject\\Component\\VTodo',
+        'VALARM'        => 'Sabre\\VObject\\Component\\VAlarm',
+        'VEVENT'        => 'Sabre\\VObject\\Component\\VEvent',
+        'VFREEBUSY'     => 'Sabre\\VObject\\Component\\VFreeBusy',
+        'VAVAILABILITY' => 'Sabre\\VObject\\Component\\VAvailability',
+        'VJOURNAL'      => 'Sabre\\VObject\\Component\\VJournal',
+        'VTIMEZONE'     => 'Sabre\\VObject\\Component\\VTimeZone',
+        'VTODO'         => 'Sabre\\VObject\\Component\\VTodo',
     );
 
     /**

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -145,6 +145,9 @@ class VCalendar extends VObject\Document {
         'PROXIMITY'      => 'Sabre\\VObject\\Property\\Text',
         'DEFAULT-ALARM'  => 'Sabre\\VObject\\Property\\Boolean',
 
+        // Additions from draft-daboo-calendar-availability-05
+        'BUSYTYPE'       => 'Sabre\\VObject\\Property\\Text',
+
     );
 
     /**

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -306,6 +306,7 @@ class VCard extends VObject\Document {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -83,7 +83,6 @@ class VEvent extends VObject\Component {
 
     }
 
-
     /**
      * A simple list of validation rules.
      *

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -94,6 +94,7 @@ class VEvent extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VFreeBusy.php
+++ b/lib/Component/VFreeBusy.php
@@ -75,6 +75,7 @@ class VFreeBusy extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VJournal.php
+++ b/lib/Component/VJournal.php
@@ -53,6 +53,7 @@ class VJournal extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VTimeZone.php
+++ b/lib/Component/VTimeZone.php
@@ -41,6 +41,7 @@ class VTimeZone extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/lib/Component/VTodo.php
+++ b/lib/Component/VTodo.php
@@ -76,6 +76,7 @@ class VTodo extends VObject\Component {
      *   * 1 - Must appear exactly once.
      *   * + - Must appear at least once.
      *   * * - Can appear any number of times.
+     *   * ? - May appear, but not more than once.
      *
      * @var array
      */

--- a/tests/VObject/Component/VAlarmTest.php
+++ b/tests/VObject/Component/VAlarmTest.php
@@ -23,7 +23,7 @@ class VAlarmTest extends \PHPUnit_Framework_TestCase {
 
         $calendar = new VCalendar();
 
-        // Hard date and time        
+        // Hard date and time
         $valarm1 = $calendar->createComponent('VALARM');
         $valarm1->add(
             $calendar->createProperty('TRIGGER', '20120312T130000Z', array('VALUE' => 'DATE-TIME'))

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -87,7 +87,7 @@ VCAL
 
     function testRFCxxxSection3_1_availabilityprop_optional_once() {
 
-        $properties = [
+        $properties = array(
             'BUSYTYPE:BUSY',
             'CLASS:PUBLIC',
             'CREATED:20111005T135125Z',
@@ -98,18 +98,18 @@ VCAL
             'PRIORITY:1',
             'SEQUENCE:0',
             'SUMMARY:Bla bla',
-            'URL:http://exampLe.org/'
-        ];
+            'URL:http://example.org/'
+        );
 
         // They are all present, only once.
         $this->assertIsValid(Reader::read($this->template($properties)));
 
         // We duplicate each one to see if it fails.
         foreach ($properties as $property) {
-            $this->assertIsNotValid(Reader::read($this->template([
+            $this->assertIsNotValid(Reader::read($this->template(array(
                 $property,
                 $property
-            ])));
+            ))));
         }
 
     }
@@ -117,20 +117,20 @@ VCAL
     function testRFCxxxSection3_1_availabilityprop_dtend_duration() {
 
         // Only DTEND.
-        $this->assertIsValid(Reader::read($this->template([
+        $this->assertIsValid(Reader::read($this->template(array(
             'DTEND:21111005T133225Z'
-        ])));
+        ))));
 
         // Only DURATION.
-        $this->assertIsValid(Reader::read($this->template([
+        $this->assertIsValid(Reader::read($this->template(array(
             'DURATION:PT1H'
-        ])));
+        ))));
 
         // Both (not allowed).
-        $this->assertIsNotValid(Reader::read($this->template([
+        $this->assertIsNotValid(Reader::read($this->template(array(
             'DTEND:21111005T133225Z',
             'DURATION:PT1H'
-        ])));
+        ))));
     }
 
     function testAvailableSubComponent() {

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -284,6 +284,42 @@ VCAL
         }
 
     }
+    function testRFCxxxSection3_2() {
+
+        $this->assertEquals(
+            'BUSY',
+            Reader::read($this->templateAvailable(array(
+                'BUSYTYPE:BUSY'
+            )))
+                ->VAVAILABILITY
+                ->AVAILABLE
+                ->BUSYTYPE
+                ->getValue()
+        );
+
+        $this->assertEquals(
+            'BUSY-UNAVAILABLE',
+            Reader::read($this->templateAvailable(array(
+                'BUSYTYPE:BUSY-UNAVAILABLE'
+            )))
+                ->VAVAILABILITY
+                ->AVAILABLE
+                ->BUSYTYPE
+                ->getValue()
+        );
+
+        $this->assertEquals(
+            'BUSY-TENTATIVE',
+            Reader::read($this->templateAvailable(array(
+                'BUSYTYPE:BUSY-TENTATIVE'
+            )))
+                ->VAVAILABILITY
+                ->AVAILABLE
+                ->BUSYTYPE
+                ->getValue()
+        );
+
+    }
 
     protected function assertIsValid(VObject\Document $document) {
 

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -149,6 +149,99 @@ VCAL;
 
     }
 
+    function testRFCxxxSection3_1_availableprop_required() {
+
+        // UID, DTSTAMP and DTSTART are present.
+        $this->assertIsValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+UID:foo@test
+DTSTAMP:20111005T133225Z
+DTSTART:20111005T133225Z
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // UID, DTSTAMP and DTSTART are missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // UID is missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+DTSTAMP:20111005T133225Z
+DTSTART:20111005T133225Z
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // DTSTAMP is missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+UID:foo@test
+DTSTART:20111005T133225Z
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // DTSTART is missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+UID:foo@test
+DTSTAMP:20111005T133225Z
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+    }
+
     protected function assertIsValid(VObject\Document $document) {
 
         $this->assertEmpty($document->validate());

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -25,7 +25,7 @@ END:VCALENDAR
 VCAL;
         $document = Reader::read($vcal);
 
-        $this->assertInstanceOf(VAvailability::class, $document->VAVAILABILITY);
+        $this->assertInstanceOf(__NAMESPACE__ . '\VAvailability', $document->VAVAILABILITY);
 
     }
 
@@ -145,7 +145,7 @@ END:VCALENDAR
 VCAL;
         $document = Reader::read($vcal);
 
-        $this->assertInstanceOf(Component::class, $document->VAVAILABILITY->AVAILABLE);
+        $this->assertInstanceOf(__NAMESPACE__, $document->VAVAILABILITY->AVAILABLE);
 
     }
 

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -242,6 +242,49 @@ VCAL
 
     }
 
+    function testRFCxxxSection3_1_available_dtend_duration() {
+
+        // Only DTEND.
+        $this->assertIsValid(Reader::read($this->templateAvailable(array(
+            'DTEND:21111005T133225Z'
+        ))));
+
+        // Only DURATION.
+        $this->assertIsValid(Reader::read($this->templateAvailable(array(
+            'DURATION:PT1H'
+        ))));
+
+        // Both (not allowed).
+        $this->assertIsNotValid(Reader::read($this->templateAvailable(array(
+            'DTEND:21111005T133225Z',
+            'DURATION:PT1H'
+        ))));
+    }
+
+    function testRFCxxxSection3_1_available_optional_once() {
+
+        $properties = array(
+            'CREATED:20111005T135125Z',
+            'DESCRIPTION:Long bla bla',
+            'LAST-MODIFIED:20111005T135325Z',
+            'RECURRENCE-ID;RANGE=THISANDFUTURE:19980401T133000Z',
+            'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+            'SUMMARY:Bla bla'
+        );
+
+        // They are all present, only once.
+        $this->assertIsValid(Reader::read($this->templateAvailable($properties)));
+
+        // We duplicate each one to see if it fails.
+        foreach ($properties as $property) {
+            $this->assertIsNotValid(Reader::read($this->templateAvailable(array(
+                $property,
+                $property
+            ))));
+        }
+
+    }
+
     protected function assertIsValid(VObject\Document $document) {
 
         $this->assertEmpty($document->validate());
@@ -256,7 +299,8 @@ VCAL
 
     protected function template(array $properties) {
 
-        $template = <<<VCAL
+        return $this->_template(
+            <<<VCAL
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//id
@@ -266,7 +310,39 @@ DTSTAMP:20111005T133225Z
 …
 END:VAVAILABILITY
 END:VCALENDAR
-VCAL;
+VCAL
+,
+            $properties
+        );
+
+    }
+
+    protected function templateAvailable(array $properties) {
+
+        return $this->_template(
+            <<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+BEGIN:AVAILABLE
+UID:foo@test
+DTSTAMP:20111005T133225Z
+DTSTART:20111005T133225Z
+…
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+,
+            $properties
+        );
+
+    }
+
+    protected function _template($template, array $properties) {
 
         return str_replace('…', implode(CRLF, $properties), $template);
 

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sabre\VObject\Component;
+
+use Sabre\VObject;
+use Sabre\VObject\Reader;
+use Sabre\VObject\Component\VAvailability;
+
+class VAvailabilityTest extends \PHPUnit_Framework_TestCase {
+
+    function testVAvailabilityComponent() {
+
+        $vcal = <<<VCAL
+BEGIN:VCALENDAR
+BEGIN:VAVAILABILITY
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL;
+        $document = Reader::read($vcal);
+
+        $this->assertInstanceOf(VAvailability::class, $document->VAVAILABILITY);
+
+    }
+
+}

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -4,6 +4,7 @@ namespace Sabre\VObject\Component;
 
 use Sabre\VObject;
 use Sabre\VObject\Reader;
+use Sabre\VObject\Component;
 use Sabre\VObject\Component\VAvailability;
 
 const CRLF = "\r\n";
@@ -130,6 +131,22 @@ VCAL
             'DTEND:21111005T133225Z',
             'DURATION:PT1H'
         ])));
+    }
+
+    function testAvailableSubComponent() {
+
+        $vcal = <<<VCAL
+BEGIN:VCALENDAR
+BEGIN:VAVAILABILITY
+BEGIN:AVAILABLE
+END:AVAILABLE
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL;
+        $document = Reader::read($vcal);
+
+        $this->assertInstanceOf(Component::class, $document->VAVAILABILITY->AVAILABLE);
+
     }
 
     protected function assertIsValid(VObject\Document $document) {

--- a/tests/VObject/Component/VAvailabilityTest.php
+++ b/tests/VObject/Component/VAvailabilityTest.php
@@ -6,6 +6,12 @@ use Sabre\VObject;
 use Sabre\VObject\Reader;
 use Sabre\VObject\Component\VAvailability;
 
+const CRLF = "\r\n";
+
+/**
+ * We use `RFCxxx` has a placeholder for the
+ * https://tools.ietf.org/html/draft-daboo-calendar-availability-05 name.
+ */
 class VAvailabilityTest extends \PHPUnit_Framework_TestCase {
 
     function testVAvailabilityComponent() {
@@ -19,6 +25,140 @@ VCAL;
         $document = Reader::read($vcal);
 
         $this->assertInstanceOf(VAvailability::class, $document->VAVAILABILITY);
+
+    }
+
+    function testRFCxxxSection3_1_availabilityprop_required() {
+
+        // UID and DTSTAMP are present.
+        $this->assertIsValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // UID and DTSTAMP are missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // DTSTAMP is missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+        // UID is missing.
+        $this->assertIsNotValid(Reader::read(
+<<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+DTSTAMP:20111005T133225Z
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL
+        ));
+
+    }
+
+    function testRFCxxxSection3_1_availabilityprop_optional_once() {
+
+        $properties = [
+            'BUSYTYPE:BUSY',
+            'CLASS:PUBLIC',
+            'CREATED:20111005T135125Z',
+            'DESCRIPTION:Long bla bla',
+            'DTSTART:20111005T020000',
+            'LAST-MODIFIED:20111005T135325Z',
+            'ORGANIZER:mailto:foo@example.com',
+            'PRIORITY:1',
+            'SEQUENCE:0',
+            'SUMMARY:Bla bla',
+            'URL:http://exampLe.org/'
+        ];
+
+        // They are all present, only once.
+        $this->assertIsValid(Reader::read($this->template($properties)));
+
+        // We duplicate each one to see if it fails.
+        foreach ($properties as $property) {
+            $this->assertIsNotValid(Reader::read($this->template([
+                $property,
+                $property
+            ])));
+        }
+
+    }
+
+    function testRFCxxxSection3_1_availabilityprop_dtend_duration() {
+
+        // Only DTEND.
+        $this->assertIsValid(Reader::read($this->template([
+            'DTEND:21111005T133225Z'
+        ])));
+
+        // Only DURATION.
+        $this->assertIsValid(Reader::read($this->template([
+            'DURATION:PT1H'
+        ])));
+
+        // Both (not allowed).
+        $this->assertIsNotValid(Reader::read($this->template([
+            'DTEND:21111005T133225Z',
+            'DURATION:PT1H'
+        ])));
+    }
+
+    protected function assertIsValid(VObject\Document $document) {
+
+        $this->assertEmpty($document->validate());
+
+    }
+
+    protected function assertIsNotValid(VObject\Document $document) {
+
+        $this->assertNotEmpty($document->validate());
+
+    }
+
+    protected function template(array $properties) {
+
+        $template = <<<VCAL
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//id
+BEGIN:VAVAILABILITY
+UID:foo@test
+DTSTAMP:20111005T133225Z
+…
+END:VAVAILABILITY
+END:VCALENDAR
+VCAL;
+
+        return str_replace('…', implode(CRLF, $properties), $template);
 
     }
 


### PR DESCRIPTION
Fix https://github.com/fruux/sabre-vobject/issues/109.
[RFC Calendar Availability draft-daboo-calendar-availability-05](https://tools.ietf.org/html/draft-daboo-calendar-availability-05).

* [x] create the new component `VAVAILABILITY`:
  * [x] create the class,
  * [x] declare the component,
  * [x] create the validation rules,
  * [x] create a useful API (not addressed in this PR),
* [x] create the new component `AVAILABLE`:
  * [x] create the class,
  * [x] declare the component,
  * [x] create the validation rules,
* [x] create the new property `BUSYTYPE`:
  * [x] declare the property,
* [x] create tests for each items above,
* [x] test with jCal (not addressed in this PR, because it's not the right branch),
* [x] test with xCal (not addressed in this PR, because it's not the right branch).

Things to check:
  * `VTIMEZONE` when having `DATE-TIME` values.