### PR TITLE
milliseconds in date time parser

### DIFF
--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -199,7 +199,7 @@ class DateTimeParser {
      * This method returns an array, not a DateTime value.
      *
      * The elements in the array are in the following order:
-     * year, month, date, hour, minute, second, millisecond, timezone
+     * year, month, date, hour, minute, second, timezone
      *
      * Almost any part of the string may be omitted. It's for example legal to
      * just specify seconds, leave out the year, etc.
@@ -260,7 +260,7 @@ class DateTimeParser {
                 (?P<minute> [0-9]{2} | -)?
                 (?P<second> [0-9]{2})?
 
-                (?: \.(?P<millisecond> [0-9]{3}))?
+                (?: \.[0-9]{3})?
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{4})
@@ -285,7 +285,7 @@ class DateTimeParser {
                     (?: (?P<minute> [0-9]{2}) : | -)?
                     (?P<second> [0-9]{2})?
 
-                    (?: \.(?P<millisecond> [0-9]{3}))?
+                    (?: \.[0-9]{3})?
                     (?P<timezone> # timezone offset
 
                         Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
@@ -307,7 +307,6 @@ class DateTimeParser {
             'hour',
             'minute',
             'second',
-            'millisecond',
             'timezone'
         );
 
@@ -334,7 +333,7 @@ class DateTimeParser {
      * This method returns an array, not a DateTime value.
      *
      * The elements in the array are in the following order:
-     * hour, minute, second, millisecond, timezone
+     * hour, minute, second, timezone
      *
      * Almost any part of the string may be omitted. It's for example legal to
      * just specify seconds, leave out the hour etc.
@@ -376,7 +375,7 @@ class DateTimeParser {
             (?P<minute> [0-9]{2} | -)?
             (?P<second> [0-9]{2})?
 
-            (?: \.(?P<millisecond> [0-9]{3}))?
+            (?: \.[0-9]{3})?
             (?P<timezone> # timezone offset
 
                 Z | (?: \+|-)(?: [0-9]{4})
@@ -393,7 +392,7 @@ class DateTimeParser {
                 (?: (?P<minute> [0-9]{2}) : | -)?
                 (?P<second> [0-9]{2})?
 
-                (?: \.(?P<millisecond> [0-9]{3}))?
+                (?: \.[0-9]{3})?
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
@@ -410,7 +409,6 @@ class DateTimeParser {
             'hour',
             'minute',
             'second',
-            'millisecond',
             'timezone'
         );
 

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -199,7 +199,7 @@ class DateTimeParser {
      * This method returns an array, not a DateTime value.
      *
      * The elements in the array are in the following order:
-     * year, month, date, hour, minute, second, timezone
+     * year, month, date, hour, minute, second, millisecond, timezone
      *
      * Almost any part of the string may be omitted. It's for example legal to
      * just specify seconds, leave out the year, etc.
@@ -334,7 +334,7 @@ class DateTimeParser {
      * This method returns an array, not a DateTime value.
      *
      * The elements in the array are in the following order:
-     * hour, minute, second, timezone
+     * hour, minute, second, millisecond, timezone
      *
      * Almost any part of the string may be omitted. It's for example legal to
      * just specify seconds, leave out the hour etc.
@@ -376,6 +376,7 @@ class DateTimeParser {
             (?P<minute> [0-9]{2} | -)?
             (?P<second> [0-9]{2})?
 
+            (?: \.(?P<millisecond> [0-9]{3}))?
             (?P<timezone> # timezone offset
 
                 Z | (?: \+|-)(?: [0-9]{4})
@@ -392,6 +393,7 @@ class DateTimeParser {
                 (?: (?P<minute> [0-9]{2}) : | -)?
                 (?P<second> [0-9]{2})?
 
+                (?: \.(?P<millisecond> [0-9]{3}))?
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
@@ -408,6 +410,7 @@ class DateTimeParser {
             'hour',
             'minute',
             'second',
+            'millisecond',
             'timezone'
         );
 

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -260,7 +260,7 @@ class DateTimeParser {
                 (?P<minute> [0-9]{2} | -)?
                 (?P<second> [0-9]{2})?
 
-                (?: \.[0-9]{3})?
+                (?: \.[0-9]{3})? # milliseconds
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{4})
@@ -285,7 +285,7 @@ class DateTimeParser {
                     (?: (?P<minute> [0-9]{2}) : | -)?
                     (?P<second> [0-9]{2})?
 
-                    (?: \.[0-9]{3})?
+                    (?: \.[0-9]{3})? # milliseconds
                     (?P<timezone> # timezone offset
 
                         Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
@@ -375,7 +375,7 @@ class DateTimeParser {
             (?P<minute> [0-9]{2} | -)?
             (?P<second> [0-9]{2})?
 
-            (?: \.[0-9]{3})?
+            (?: \.[0-9]{3})? # milliseconds
             (?P<timezone> # timezone offset
 
                 Z | (?: \+|-)(?: [0-9]{4})
@@ -392,7 +392,7 @@ class DateTimeParser {
                 (?: (?P<minute> [0-9]{2}) : | -)?
                 (?P<second> [0-9]{2})?
 
-                (?: \.[0-9]{3})?
+                (?: \.[0-9]{3})? # milliseconds
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})

--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -260,6 +260,7 @@ class DateTimeParser {
                 (?P<minute> [0-9]{2} | -)?
                 (?P<second> [0-9]{2})?
 
+                (?: \.(?P<millisecond> [0-9]{3}))?
                 (?P<timezone> # timezone offset
 
                     Z | (?: \+|-)(?: [0-9]{4})
@@ -268,7 +269,6 @@ class DateTimeParser {
 
             )?
             $/x';
-
 
         if (!preg_match($regex, $date, $matches)) {
 
@@ -285,6 +285,7 @@ class DateTimeParser {
                     (?: (?P<minute> [0-9]{2}) : | -)?
                     (?P<second> [0-9]{2})?
 
+                    (?: \.(?P<millisecond> [0-9]{3}))?
                     (?P<timezone> # timezone offset
 
                         Z | (?: \+|-)(?: [0-9]{2}:[0-9]{2})
@@ -306,6 +307,7 @@ class DateTimeParser {
             'hour',
             'minute',
             'second',
+            'millisecond',
             'timezone'
         );
 

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -196,6 +196,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => 00,
                     "second" => 00,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -208,6 +209,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => 00,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -220,6 +222,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -232,6 +235,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -244,6 +248,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -256,6 +261,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -268,6 +274,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -280,6 +287,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -292,6 +300,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 0,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -304,6 +313,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -316,6 +326,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => null,
                     "second" => null,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -328,6 +339,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => 22,
                     "second" => 00,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -340,6 +352,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => 00,
+                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -352,6 +365,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 00,
+                    "millisecond" => null,
                     "timezone" => 'Z'
                 ),
             ),
@@ -364,6 +378,7 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 00,
+                    "millisecond" => null,
                     "timezone" => '-0800'
                 ),
             ),
@@ -378,12 +393,43 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 15,
                     "minute" => 10,
                     "second" => 53,
+                    "millisecond" => null,
                     "timezone" => 'Z'
                 ),
             ),
+
+            // with milliseconds
+            array(
+                "20121129T151053.123Z",
+                array(
+                    "year" => 2012,
+                    "month" => 11,
+                    "date" => 29,
+                    "hour" => 15,
+                    "minute" => 10,
+                    "second" => 53,
+                    "millisecond" => 123,
+                    "timezone" => 'Z'
+                ),
+            ),
+
+            // extended format with milliseconds
+            array(
+                "2012-11-29T15:10:53.123Z",
+                array(
+                    "year" => 2012,
+                    "month" => 11,
+                    "date" => 29,
+                    "hour" => 15,
+                    "minute" => 10,
+                    "second" => 53,
+                    "millisecond" => 123,
+                    "timezone" => 'Z'
+                ),
+            ),
+
         );
 
     }
-
 
 }

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -196,7 +196,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => 00,
                     "second" => 00,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -209,7 +208,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => 00,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -222,7 +220,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 14,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -235,7 +232,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -248,7 +244,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -261,7 +256,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -274,7 +268,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -287,7 +280,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -300,7 +292,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 0,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -313,7 +304,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -326,7 +316,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => null,
                     "second" => null,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -339,7 +328,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => 22,
                     "second" => 00,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -352,7 +340,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => null,
                     "minute" => null,
                     "second" => 00,
-                    "millisecond" => null,
                     "timezone" => null
                 ),
             ),
@@ -365,7 +352,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 00,
-                    "millisecond" => null,
                     "timezone" => 'Z'
                 ),
             ),
@@ -378,7 +364,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 10,
                     "minute" => 22,
                     "second" => 00,
-                    "millisecond" => null,
                     "timezone" => '-0800'
                 ),
             ),
@@ -393,7 +378,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 15,
                     "minute" => 10,
                     "second" => 53,
-                    "millisecond" => null,
                     "timezone" => 'Z'
                 ),
             ),
@@ -408,7 +392,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 15,
                     "minute" => 10,
                     "second" => 53,
-                    "millisecond" => 123,
                     "timezone" => 'Z'
                 ),
             ),
@@ -423,7 +406,6 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
                     "hour" => 15,
                     "minute" => 10,
                     "second" => 53,
-                    "millisecond" => 123,
                     "timezone" => 'Z'
                 ),
             ),


### PR DESCRIPTION
We came across some cards (generated by an export on mailbox.org) that had milliseconds in a property-value (REV in this instance), for example:
```
BEGIN:VCARD
VERSION:3.0
PRODID:OPEN-XCHANGE
FN:Armin Hackmann
N:Hackmann;Armin;;;
X-OPEN-XCHANGE-CTYPE:contact
REV:20140905T151124.056Z
UID:d91b949e-69ef-41a8-a1c3-ff6a7743973c
END:VCARD
```

If we'd want to convert a card containing this to another version, the DateTimeParser would exit with an InvalidArgumentException. While the behavior is correct (according to the spec, there shouldn't be a property-value containing milliseconds), I wonder if we should support parsing such a date-time/time value?