### PR TITLE
Test for outlook encoding issue

### DIFF
--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -308,7 +308,7 @@ IN;
         $vcard = Reader::read($input);
         $vcard = $vcard->convert(Document::VCARD40);
 
-        //Calling validate(Node:REPAIR) would fix the encoding
+        //Calling validate(Node::REPAIR) would fix the encoding
         //$vcard->validate(Node::REPAIR);
         $vcard = $vcard->jsonSerialize();
 

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -256,8 +256,8 @@ OUT;
         $input = <<<IN
 BEGIN:VCARD
 VERSION:3.0
-N;ENCODING=QUOTED-PRINTABLE:;Test=DF=E4=F6=FC=C4=D6;;;
-FN;ENCODING=QUOTED-PRINTABLE:Test=DF=E4=F6=FC=C4=D6
+N;ENCODING=QUOTED-PRINTABLE:;Test=DF=E4=F6=FC=C4=D6=DC;;;
+FN;ENCODING=QUOTED-PRINTABLE:Test=DF=E4=F6=FC=C4=D6=DC
 REV:20150326T154124Z
 UID:foo
 END:VCARD
@@ -307,6 +307,9 @@ IN;
 
         $vcard = Reader::read($input);
         $vcard = $vcard->convert(Document::VCARD40);
+
+        //Calling validate(Node:REPAIR) would fix the encoding
+        //$vcard->validate(Node::REPAIR);
         $vcard = $vcard->jsonSerialize();
 
         $this->assertEquals(

--- a/tests/VObject/VCardConverterTest.php
+++ b/tests/VObject/VCardConverterTest.php
@@ -251,6 +251,71 @@ OUT;
 
     }
 
+    function testQuotedPrintabletoJcard() {
+
+        $input = <<<IN
+BEGIN:VCARD
+VERSION:3.0
+N;ENCODING=QUOTED-PRINTABLE:;Test=DF=E4=F6=FC=C4=D6;;;
+FN;ENCODING=QUOTED-PRINTABLE:Test=DF=E4=F6=FC=C4=D6
+REV:20150326T154124Z
+UID:foo
+END:VCARD
+IN;
+
+        $expected = array(
+            "vcard",
+            array(
+                array(
+                    "version",
+                    new \StdClass(),
+                    "text",
+                    "4.0"
+                ),
+                array(
+                    "prodid",
+                    new \StdClass(),
+                    "text",
+                    "-//Sabre//Sabre VObject " . Version::VERSION . "//EN",
+                ),
+                array(
+                    "n",
+                    new \StdClass(),
+                    "text",
+                    array("", "TestßäöüÄÖÜ", "", "", ""),
+                ),
+                array(
+                    "fn",
+                    new \StdClass(),
+                    "text",
+                    "TestßäöüÄÖÜ",
+                ),
+                array(
+                    "rev",
+                    new \StdClass(),
+                    "timestamp",
+                    "2015-03-26T15:41:24Z",
+                ),
+                array(
+                    "uid",
+                    new \StdClass(),
+                    "text",
+                    "foo",
+                ),
+              ),
+            );
+
+        $vcard = Reader::read($input);
+        $vcard = $vcard->convert(Document::VCARD40);
+        $vcard = $vcard->jsonSerialize();
+
+        $this->assertEquals(
+            $expected,
+            $vcard
+        );
+
+    }
+
     function testBDAYConversion() {
 
         $input = <<<IN


### PR DESCRIPTION
Outlook encodes characters (like Umlauts) like this:

```
FN;ENCODING=QUOTED-PRINTABLE:Test=DF=E4=F6=FC=C4=D6
```

When we convert to vCard 4.0 and then to jCard it seems like the conversion fails, as we're not converting to the expected result: `TestßäöüÄÖÜ`