### PR TITLE
vEvent->isInTimeRange() fails for all-day events that end on start of given time range

### DIFF
--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -53,6 +53,9 @@ class VEvent extends VObject\Component {
             // See:
             // http://tools.ietf.org/html/rfc5545#page-54
             $effectiveEnd = $this->DTEND->getDateTime();
+            if (!$this->DTEND->hasTime()) {
+                $effectiveEnd->modify('-1 second');
+            }
 
         } elseif (isset($this->DURATION)) {
             $effectiveEnd = clone $effectiveStart;
@@ -60,6 +63,7 @@ class VEvent extends VObject\Component {
         } elseif (!$this->DTSTART->hasTime()) {
             $effectiveEnd = clone $effectiveStart;
             $effectiveEnd->modify('+1 day');
+            $effectiveEnd->modify('-1 second');
         } else {
             $effectiveEnd = clone $effectiveStart;
         }

--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -43,7 +43,7 @@ class VEvent extends VObject\Component {
 
         }
 
-        $effectiveStart = $this->DTSTART->getDateTime();
+        $effectiveStart = $this->DTSTART->getDateTime($start->getTimezone());
         if (isset($this->DTEND)) {
 
             // The DTEND property is considered non inclusive. So for a 3 day
@@ -52,7 +52,7 @@ class VEvent extends VObject\Component {
             //
             // See:
             // http://tools.ietf.org/html/rfc5545#page-54
-            $effectiveEnd = $this->DTEND->getDateTime();
+            $effectiveEnd = $this->DTEND->getDateTime($end->getTimezone());
             if (!$this->DTEND->hasTime()) {
                 $effectiveEnd->modify('-1 second');
             }

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -43,7 +43,10 @@ class VEventTest extends \PHPUnit_Framework_TestCase {
         $tests[] = array($vevent4, new \DateTime('2011-01-01'), new \DateTime('2011-11-01'), false);
         // Event with no end date should be treated as lasting the entire day.
         $tests[] = array($vevent4, new \DateTime('2011-12-25 16:00:00'), new \DateTime('2011-12-25 17:00:00'), true);
-
+        // DTEND is non inclusive so all day events should not be returned on the next day.
+        $tests[] = array($vevent4, new \DateTime('2011-12-26 00:00:00'), new \DateTime('2011-12-26 17:00:00'), false);
+        // The timezone of timerange in question also needs to be considered.
+        $tests[] = array($vevent4, new \DateTime('2011-12-26 00:00:00', new \DateTimeZone('Europe/Berlin')), new \DateTime('2011-12-26 17:00:00', new \DateTimeZone('Europe/Berlin')), false);
 
         $vevent5 = clone $vevent;
         $vevent5->DURATION = 'P1D';


### PR DESCRIPTION
`DTEND` should be non inclusive (see http://tools.ietf.org/html/rfc5545#page-54), but `VEVENT->isInTimeRange()` will return events that ended the day before. Additionally the timezone of the timerange should be considered.

Unit tests for these two cases are included as well as a fix for each.