### PR TITLE
Identify "+00:00" as UTC

### DIFF
--- a/lib/Property/ICalendar/DateTime.php
+++ b/lib/Property/ICalendar/DateTime.php
@@ -224,7 +224,7 @@ class DateTime extends Property {
                 }
                 if (is_null($tz)) {
                     $tz = $d->getTimeZone();
-                    $isUtc = in_array($tz->getName(), ['UTC', 'GMT', 'Z']);
+                    $isUtc = in_array($tz->getName(), ['UTC', 'GMT', 'Z', '+00:00']);
                     if (!$isUtc) {
                         $this->offsetSet('TZID', $tz->getName());
                     }

--- a/tests/VObject/Property/ICalendar/DateTimeTest.php
+++ b/tests/VObject/Property/ICalendar/DateTimeTest.php
@@ -63,6 +63,20 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($elem->hasTime());
     }
 
+    function testSetDateTimeFromUnixTimestamp() {
+
+        // When initialized from a Unix timestamp, the timezone is set to "+00:00".
+        $dt = new \DateTime('@489288600');
+
+        $elem = $this->vcal->createProperty('DTSTART');
+        $elem->setDateTime($dt);
+
+        $this->assertEquals('19850704T013000Z', (string)$elem);
+        $this->assertNull($elem['TZID']);
+
+        $this->assertTrue($elem->hasTime());
+    }
+
     function testSetDateTimeLOCALTZ() {
 
         $tz = new \DateTimeZone('Europe/Amsterdam');


### PR DESCRIPTION
When a DateTime object is created from a Unix timestamp using the @ syntax, `new \DateTime('@123456789')`, the resulting object gets a timezone with the name `+00:00` (tested with PHP 5.5.25 and 5.4.38). Passing a timezone object as the second argument does not change this.

This timezone represents UTC, but it is not identified as a UTC timezone in VObject\Property\ICalendar\DateTime.

This PR adds `+00:00` to the list of known aliases for UTC.

(BTW, there are [other aliases](http://php.net/manual/en/timezones.others.php), but they are all deprecated)