### PR TITLE
Added a garbage collector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ ChangeLog
 * Removed `RecurrenceIterator` (use Recur\EventIterator instead).
 * Now using php-cs-fixer to automatically enforce and correct CS.
 * #233: The `+00:00` timezone is now recognized as UTC. (@c960657)
+* #237: Added a `destroy()` method to all documents. This method breaks any
+  circular references, allowing PHP to free up memory.
 
 
 3.4.5 (2015-06-02)

--- a/bin/bench_manipulatevcard.php
+++ b/bin/bench_manipulatevcard.php
@@ -41,6 +41,8 @@ while (true) {
     $vcard2 = $vcard->serialize();
     $bench->serialize->pause();
 
+    $vcard->destroy();
+
 }
 
 

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -154,18 +154,17 @@ class Component extends Node {
                 $child->destroy();
                 unset($this->children[$k]);
             }
-            return $child;
-        } else {
-            foreach ($this->children as $k => $child) {
-                if ($child === $item) {
-                    $child->destroy();
-                    unset($this->children[$k]);
-                }
-            }
-
-            throw new \InvalidArgumentException('The item you passed to remove() was not a child of this component');
-
+            return;
         }
+        foreach ($this->children as $k => $child) {
+            if ($child === $item) {
+                $child->destroy();
+                unset($this->children[$k]);
+                return;
+            }
+        }
+
+        throw new \InvalidArgumentException('The item you passed to remove() was not a child of this component');
 
     }
 

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -142,9 +142,6 @@ class Component extends Node {
      * pass an instance of a property or component, in which case only that
      * exact item will be removed.
      *
-     * The removed item will be returned. In case there were more than 1 items
-     * removed, only the last one will be returned.
-     *
      * @param mixed $item
      *
      * @return void
@@ -154,14 +151,15 @@ class Component extends Node {
         if (is_string($item)) {
             $children = $this->select($item);
             foreach ($children as $k => $child) {
+                $child->destroy();
                 unset($this->children[$k]);
             }
             return $child;
         } else {
             foreach ($this->children as $k => $child) {
                 if ($child === $item) {
+                    $child->destroy();
                     unset($this->children[$k]);
-                    return $child;
                 }
             }
 
@@ -650,6 +648,26 @@ class Component extends Node {
 
         }
         return $messages;
+
+    }
+
+    /**
+     * Call this method on a document if you're done using it.
+     *
+     * It's intended to remove all circular references, so PHP can easily clean
+     * it up.
+     *
+     * @return void
+     */
+    function destroy() {
+
+        parent::destroy();
+        foreach($this->children as $childGroup) {
+            foreach($childGroup as $child) {
+                $child->destroy();
+            }
+        }
+        $this->children = [];
 
     }
 

--- a/lib/Component.php
+++ b/lib/Component.php
@@ -661,8 +661,8 @@ class Component extends Node {
     function destroy() {
 
         parent::destroy();
-        foreach($this->children as $childGroup) {
-            foreach($childGroup as $child) {
+        foreach ($this->children as $childGroup) {
+            foreach ($childGroup as $child) {
                 $child->destroy();
             }
         }

--- a/lib/Node.php
+++ b/lib/Node.php
@@ -90,6 +90,21 @@ abstract class Node
      */
     abstract function xmlSerialize(Xml\Writer $writer);
 
+    /**
+     * Call this method on a document if you're done using it.
+     *
+     * It's intended to remove all circular references, so PHP can easily clean
+     * it up.
+     *
+     * @return void
+     */
+    function destroy() {
+
+        $this->parent = null;
+        $this->root = null;
+
+    }
+
     /* {{{ IteratorAggregator interface */
 
     /**

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -641,4 +641,22 @@ abstract class Property extends Node {
 
     }
 
+    /**
+     * Call this method on a document if you're done using it.
+     *
+     * It's intended to remove all circular references, so PHP can easily clean
+     * it up.
+     *
+     * @return void
+     */
+    function destroy() {
+
+        parent::destroy();
+        foreach($this->parameters as $param) {
+            $param->destroy();
+        }
+        $this->parameters = [];
+
+    }
+
 }

--- a/lib/Property.php
+++ b/lib/Property.php
@@ -652,7 +652,7 @@ abstract class Property extends Node {
     function destroy() {
 
         parent::destroy();
-        foreach($this->parameters as $param) {
+        foreach ($this->parameters as $param) {
             $param->destroy();
         }
         $this->parameters = [];

--- a/tests/VObject/DocumentTest.php
+++ b/tests/VObject/DocumentTest.php
@@ -78,7 +78,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase {
 
         $vcal->destroy();
 
-        $this->assertNull($event, $prop->parent);
+        $this->assertNull($prop->parent);
 
 
     }

--- a/tests/VObject/DocumentTest.php
+++ b/tests/VObject/DocumentTest.php
@@ -62,6 +62,27 @@ class DocumentTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testDestroy() {
+
+        $vcal = new Component\VCalendar([], false);
+        $event = $vcal->createComponent('VEVENT');
+
+        $this->assertInstanceOf('Sabre\VObject\Component\VEvent', $event);
+        $vcal->add($event);
+
+        $prop = $vcal->createProperty('X-PROP', '1234256', ['X-PARAM' => '3']);
+
+        $event->add($prop);
+
+        $this->assertEquals($event, $prop->parent);
+
+        $vcal->destroy();
+
+        $this->assertNull($event, $prop->parent);
+
+
+    }
+
 }
 
 

--- a/tests/VObject/Property/ICalendar/RecurTest.php
+++ b/tests/VObject/Property/ICalendar/RecurTest.php
@@ -14,7 +14,7 @@ class RecurTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Sabre\VObject\Property\ICalendar\Recur', $recur);
 
         $this->assertEquals(['FREQ' => 'DAILY'], $recur->getParts());
-        $recur->setParts(['freq'   => 'MONTHLY']);
+        $recur->setParts(['freq'    => 'MONTHLY']);
 
         $this->assertEquals(['FREQ' => 'MONTHLY'], $recur->getParts());
 

--- a/tests/VObject/Property/TextTest.php
+++ b/tests/VObject/Property/TextTest.php
@@ -10,7 +10,7 @@ class TextTest extends \PHPUnit_Framework_TestCase {
 
         $doc = new VCard([
             'VERSION' => '2.1',
-            'PROP'   => $propValue
+            'PROP'    => $propValue
         ], false);
 
         // Adding quoted-printable, because we're testing if it gets removed


### PR DESCRIPTION
vobject documents stay in PHP's memory, even after they are no longer used. This is because there's a lot of circular references, which _can_ be resolved by calling `gc_collect_cycles()`, but this is not optimal.

This PR adds a `destroy()` method to all documents, components, etc, which allows a user to simply indicate that they no longer intend to use the object. This method breaks all circular references, which allows PHP to clean up the object.

While this might not be useful everywhere, this can cause massive memory savings in cases where a lot of objects are manipulated.