### PR TITLE
PHP 7 and HHVM  support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
-    - php: 7
 
 script:
   - phpunit --configuration tests/phpunit.xml

--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -57,8 +57,8 @@ class VCalendar extends VObject\Document {
         'DATE'             => 'Sabre\\VObject\\Property\\ICalendar\\Date',
         'DATE-TIME'        => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
         'DURATION'         => 'Sabre\\VObject\\Property\\ICalendar\\Duration',
-        'FLOAT'            => 'Sabre\\VObject\\Property\\Float',
-        'INTEGER'          => 'Sabre\\VObject\\Property\\Integer',
+        'FLOAT'            => 'Sabre\\VObject\\Property\\FloatValue',
+        'INTEGER'          => 'Sabre\\VObject\\Property\\IntegerValue',
         'PERIOD'           => 'Sabre\\VObject\\Property\\ICalendar\\Period',
         'RECUR'            => 'Sabre\\VObject\\Property\\ICalendar\\Recur',
         'TEXT'             => 'Sabre\\VObject\\Property\\Text',
@@ -86,10 +86,10 @@ class VCalendar extends VObject\Document {
         'CLASS'             => 'Sabre\\VObject\\Property\\FlatText',
         'COMMENT'           => 'Sabre\\VObject\\Property\\FlatText',
         'DESCRIPTION'       => 'Sabre\\VObject\\Property\\FlatText',
-        'GEO'               => 'Sabre\\VObject\\Property\\Float',
+        'GEO'               => 'Sabre\\VObject\\Property\\FloatValue',
         'LOCATION'          => 'Sabre\\VObject\\Property\\FlatText',
-        'PERCENT-COMPLETE'  => 'Sabre\\VObject\\Property\\Integer',
-        'PRIORITY'          => 'Sabre\\VObject\\Property\\Integer',
+        'PERCENT-COMPLETE'  => 'Sabre\\VObject\\Property\\IntegerValue',
+        'PRIORITY'          => 'Sabre\\VObject\\Property\\IntegerValue',
         'RESOURCES'         => 'Sabre\\VObject\\Property\\Text',
         'STATUS'            => 'Sabre\\VObject\\Property\\FlatText',
         'SUMMARY'           => 'Sabre\\VObject\\Property\\FlatText',
@@ -127,14 +127,14 @@ class VCalendar extends VObject\Document {
 
         // Alarm Component Properties
         'ACTION'        => 'Sabre\\VObject\\Property\\FlatText',
-        'REPEAT'        => 'Sabre\\VObject\\Property\\Integer',
+        'REPEAT'        => 'Sabre\\VObject\\Property\\IntegerValue',
         'TRIGGER'       => 'Sabre\\VObject\\Property\\ICalendar\\Duration',
 
         // Change Management Component Properties
         'CREATED'       => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
         'DTSTAMP'       => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
         'LAST-MODIFIED' => 'Sabre\\VObject\\Property\\ICalendar\\DateTime',
-        'SEQUENCE'      => 'Sabre\\VObject\\Property\\Integer',
+        'SEQUENCE'      => 'Sabre\\VObject\\Property\\IntegerValue',
 
         // Request Status
         'REQUEST-STATUS' => 'Sabre\\VObject\\Property\\Text',

--- a/lib/Component/VCard.php
+++ b/lib/Component/VCard.php
@@ -45,8 +45,8 @@ class VCard extends VObject\Document {
         'DATE'             => 'Sabre\\VObject\\Property\\VCard\\Date',
         'DATE-TIME'        => 'Sabre\\VObject\\Property\\VCard\\DateTime',
         'DATE-AND-OR-TIME' => 'Sabre\\VObject\\Property\\VCard\\DateAndOrTime', // vCard only
-        'FLOAT'            => 'Sabre\\VObject\\Property\\Float',
-        'INTEGER'          => 'Sabre\\VObject\\Property\\Integer',
+        'FLOAT'            => 'Sabre\\VObject\\Property\\FloatValue',
+        'INTEGER'          => 'Sabre\\VObject\\Property\\IntegerValue',
         'LANGUAGE-TAG'     => 'Sabre\\VObject\\Property\\VCard\\LanguageTag',
         'TIMESTAMP'        => 'Sabre\\VObject\\Property\\VCard\\TimeStamp',
         'TEXT'             => 'Sabre\\VObject\\Property\\Text',

--- a/lib/Property/FloatValue.php
+++ b/lib/Property/FloatValue.php
@@ -15,7 +15,7 @@ use Sabre\Xml;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Float extends Property {
+class FloatValue extends Property {
 
     /**
      * In case this is a multi-value property. This string will be used as a

--- a/lib/Property/IntegerValue.php
+++ b/lib/Property/IntegerValue.php
@@ -15,7 +15,7 @@ use
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Integer extends Property {
+class IntegerValue extends Property {
 
     /**
      * Sets a raw value coming from a mimedir (iCalendar/vCard) file.

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -491,7 +491,11 @@ class RRuleIterator implements Iterator {
 
         }
 
-        $this->currentDate = $this->currentDate->setDate($this->currentDate->format('Y'), $this->currentDate->format('n'), $occurrence);
+        $this->currentDate = $this->currentDate->setDate(
+            (int)$this->currentDate->format('Y'),
+            (int)$this->currentDate->format('n'),
+            $occurrence
+        );
 
     }
 
@@ -578,12 +582,20 @@ class RRuleIterator implements Iterator {
                     }
                 } while (!in_array($currentMonth, $this->byMonth));
 
-                $this->currentDate = $this->currentDate->setDate($currentYear, $currentMonth, $currentDayOfMonth);
+                $this->currentDate = $this->currentDate->setDate(
+                    (int)$currentYear,
+                    (int)$currentMonth,
+                    (int)$currentDayOfMonth
+                );
 
             }
 
             // If we made it here, it means we got a valid occurrence
-            $this->currentDate = $this->currentDate->setDate($currentYear, $currentMonth, $occurrence);
+            $this->currentDate = $this->currentDate->setDate(
+                (int)$currentYear,
+                (int)$currentMonth,
+                (int)$occurrence
+            );
             return;
 
         } else {
@@ -598,7 +610,11 @@ class RRuleIterator implements Iterator {
                     $currentMonth = 1;
                 }
             } while (!in_array($currentMonth, $this->byMonth));
-            $this->currentDate = $this->currentDate->setDate($currentYear, $currentMonth, $currentDayOfMonth);
+            $this->currentDate = $this->currentDate->setDate(
+                (int)$currentYear,
+                (int)$currentMonth,
+                (int)$currentDayOfMonth
+            );
 
             return;
 

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -494,7 +494,7 @@ class RRuleIterator implements Iterator {
         $this->currentDate = $this->currentDate->setDate(
             (int)$this->currentDate->format('Y'),
             (int)$this->currentDate->format('n'),
-            $occurrence
+            (int)$occurrence
         );
 
     }

--- a/tests/VObject/Property/FloatTest.php
+++ b/tests/VObject/Property/FloatTest.php
@@ -13,7 +13,7 @@ class FloatTest extends \PHPUnit_Framework_TestCase {
 
         $result = $mimeDir->parse($input);
 
-        $this->assertInstanceOf('Sabre\VObject\Property\Float', $result->{'X-FLOAT'});
+        $this->assertInstanceOf('Sabre\VObject\Property\FloatValue', $result->{'X-FLOAT'});
 
         $this->assertEquals([
             0.234,


### PR DESCRIPTION
In this PR i'll make sure that both HHVM and PHP7 are supported. HHVM was supported before, but broken as of a little while due to a php incompatibility.

PHP7 no longer allows keywords such as Integer and Float to be used as classnames, so we're renaming those.