### PR TITLE
Fix for isInTimeRange for recurring all day events in timezone

### DIFF
--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -32,7 +32,7 @@ class VEvent extends VObject\Component {
     function isInTimeRange(DateTimeInterface $start, DateTimeInterface $end) {
 
         if ($this->RRULE) {
-            $it = new EventIterator($this);
+            $it = new EventIterator($this, null, $start->getTimezone());
             $it->fastForward($start);
 
             // We fast-forwarded to a spot where the end-time of the

--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -92,7 +92,7 @@ class EventIterator implements \Iterator {
      */
     function __construct($input, $uid = null, DateTimeZone $timeZone = null) {
 
-        if (is_null($this->timeZone)) {
+        if (is_null($timeZone)) {
             $timeZone = new DateTimeZone('UTC');
         }
         $this->timeZone = $timeZone;

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -69,6 +69,8 @@ class VEventTest extends \PHPUnit_Framework_TestCase {
         $vevent7->DTSTART['VALUE'] = 'DATE';
         $vevent7->RRULE = 'FREQ=MONTHLY';
         $tests[] = [$vevent7, new \DateTime('2012-02-01 15:00:00'), new \DateTime('2012-02-02'), true];
+        // The timezone of timerange in question should also be considered.
+        $tests[] = [$vevent7, new \DateTime('2012-02-02 00:00:00', new \DateTimeZone('Europe/Berlin')), new \DateTime('2012-02-03 00:00:00', new \DateTimeZone('Europe/Berlin')), false];
         return $tests;
 
     }


### PR DESCRIPTION
Recurring all-day events are incorrectly included in time range requests when not using UTC in the time range.

e.g. (also see added unit test)
* All day event on every 1st of the month
* `isInTimeRange()` for the 2nd of a month 'Europe\Berlin`
* event would pass the test

This PR fixes that issue and a typo on initialization of `\Recur\EventIterator()`.