### PR TITLE
Skip cards without FN in BirthdayCalendarGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ ChangeLog
 * #239: Added a `BirthdayCalendarGenerator`. (@DominikTo)
 * #250: `isInTimeRange()` now considers the timezone for floating dates and
   times. (@armin-hackmann)
+* #251: `BirthdayCalendarGenerator` now skips cards that have no FN property.
+  (@DominikTo)
 
 
 4.0.0-alpha1 (2015-07-17)

--- a/lib/BirthdayCalendarGenerator.php
+++ b/lib/BirthdayCalendarGenerator.php
@@ -124,6 +124,11 @@ class BirthdayCalendarGenerator {
             // VCardConverter handling the X-APPLE-OMIT-YEAR property for us.
             $object = $object->convert(Document::VCARD40);
 
+            // Skip if the card has no FN property.
+            if (!isset($object->FN)) {
+                continue;
+            }
+
             // Skip if the BDAY property is not of the right type.
             if (!$object->BDAY instanceof Property\VCard\DateAndOrTime) {
                 continue;
@@ -133,11 +138,6 @@ class BirthdayCalendarGenerator {
             try {
                 $dateParts = DateTimeParser::parseVCardDateTime($object->BDAY->getValue());
             } catch (\InvalidArgumentException $e) {
-                continue;
-            }
-
-            // Skip if the card has no FN property.
-            if (!isset($object->FN)) {
                 continue;
             }
 

--- a/lib/BirthdayCalendarGenerator.php
+++ b/lib/BirthdayCalendarGenerator.php
@@ -136,6 +136,11 @@ class BirthdayCalendarGenerator {
                 continue;
             }
 
+            // Skip if the card has no FN property.
+            if (!isset($object->FN)) {
+                continue;
+            }
+
             // Set a year if it's not set.
             $unknownYear = false;
 

--- a/tests/VObject/BirthdayCalendarGeneratorTest.php
+++ b/tests/VObject/BirthdayCalendarGeneratorTest.php
@@ -478,4 +478,32 @@ VCF;
 
     }
 
+    function testBrokenVcardWithoutFN() {
+
+        $generator = new BirthdayCalendarGenerator();
+        $input = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+N:Gump;Forrest;;Mr.
+BDAY:19850407
+UID:foo
+END:VCARD
+VCF;
+
+        $expected = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+END:VCALENDAR
+ICS;
+
+        $generator->setObjects($input);
+        $output = $generator->getResult();
+
+        $this->assertVObjEquals(
+            $expected,
+            $output
+        );
+
+    }
+
 }


### PR DESCRIPTION
Instead of failing on `FN->getValue()` we're now skipping cards that don't have a FN.