### PR TITLE
Support for encodings other than UTF-8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ ChangeLog
   `Component\VCalendar` or `Component\VCard` during parsing.
 * #263: Lots of small cleanups. (@jakobsack)
 * #220: Automatically stop recurring after 3500 recurrences.
+* #41: Allow user to set different encoding than UTF-8 when decoding vCards.
+* #41: Support the `ENCODING` parameter from vCard 2.1.
 
 
 4.0.0-alpha2 (2015-09-04)

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -454,7 +454,7 @@ class MimeDir extends Parser {
                 // vCard 2.1 allows the character set to be specified per property.
                 $charset = (string)$propObj['CHARSET'];
             }
-            switch($charset) {
+            switch ($charset) {
                 case 'UTF-8' :
                     break;
                 case 'ISO-8859-1' :

--- a/lib/Parser/MimeDir.php
+++ b/lib/Parser/MimeDir.php
@@ -38,6 +38,20 @@ class MimeDir extends Parser {
     protected $root;
 
     /**
+     * By default all input will be assumed to be UTF-8.
+     *
+     * However, both iCalendar and vCard might be encoded using different
+     * character sets. The character set is usually set in the mime-type.
+     *
+     * If this is the case, use setEncoding to specify that a different
+     * encoding will be used. If this is set, the parser will automatically
+     * convert all incoming data to UTF-8.
+     *
+     * @var string
+     */
+    protected $charset = 'UTF-8';
+
+    /**
      * Parses an iCalendar or vCard file.
      *
      * Pass a stream or a string. If null is parsed, the existing buffer is
@@ -63,6 +77,29 @@ class MimeDir extends Parser {
         $this->parseDocument();
 
         return $this->root;
+
+    }
+
+    /**
+     * By default all input will be assumed to be UTF-8.
+     *
+     * However, both iCalendar and vCard might be encoded using different
+     * character sets. The character set is usually set in the mime-type.
+     *
+     * If this is the case, use setEncoding to specify that a different
+     * encoding will be used. If this is set, the parser will automatically
+     * convert all incoming data to UTF-8.
+     *
+     * @param string $charset
+     */
+    function setCharset($charset) {
+
+        $supportedEncodings = ['UTF-8', 'ISO-8859-1'];
+
+        if (!in_array($charset, $supportedEncodings)) {
+            throw new \InvalidArgumentException('Unsupported encoding. (Supported encodings: ' . implode(', ', $supportedEncodings) . ')');
+        }
+        $this->charset = $charset;
 
     }
 
@@ -412,6 +449,20 @@ class MimeDir extends Parser {
         if (strtoupper($propObj['ENCODING']) === 'QUOTED-PRINTABLE') {
             $propObj->setQuotedPrintableValue($this->extractQuotedPrintableValue());
         } else {
+            $charset = $this->charset;
+            if (isset($propObj['CHARSET'])) {
+                // vCard 2.1 allows the character set to be specified per property.
+                $charset = (string)$propObj['CHARSET'];
+            }
+            switch($charset) {
+                case 'UTF-8' :
+                    break;
+                case 'ISO-8859-1' :
+                    $property['value'] = utf8_encode($property['value']);
+                    break;
+                default :
+                    throw new ParseException('Unsupported CHARSET: ' . $propObj['CHARSET']);
+            }
             $propObj->setRawMimeDirValue($property['value']);
         }
 

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -18,4 +18,53 @@ class MimeDirTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testDecodeLatin1() {
+
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+FN:umlaut u - \xFC
+END:VCARD\n
+VCF;
+
+        $mimeDir = new Mimedir();
+        $mimeDir->setCharSet('ISO-8859-1');
+        $vcard = $mimeDir->parse($vcard);
+        $this->assertEquals("umlaut u - \xC3\xBC", $vcard->FN->getValue());
+
+    }
+
+    function testDecodeInlineLatin1() {
+
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:2.1
+FN;CHARSET=ISO-8859-1:umlaut u - \xFC
+END:VCARD\n
+VCF;
+
+        $mimeDir = new Mimedir();
+        $vcard = $mimeDir->parse($vcard);
+        $this->assertEquals("umlaut u - \xC3\xBC", $vcard->FN->getValue());
+
+    }
+
+    function testDontDecodeLatin1() {
+
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:4.0
+FN:umlaut u - \xFC
+END:VCARD\n
+VCF;
+
+        $mimeDir = new Mimedir();
+        $vcard = $mimeDir->parse($vcard);
+        // This basically tests that we don't touch the input string if
+        // the encoding was set to UTF-8. The result is actually invalid
+        // and the validator should report this, but it tests effectively
+        // that we pass through the string byte-by-byte.
+        $this->assertEquals("umlaut u - \xFC", $vcard->FN->getValue());
+
+    }
 }

--- a/tests/VObject/Parser/MimeDirTest.php
+++ b/tests/VObject/Parser/MimeDirTest.php
@@ -67,4 +67,31 @@ VCF;
         $this->assertEquals("umlaut u - \xFC", $vcard->FN->getValue());
 
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    function testDecodeUnsupportedCharset() {
+
+        $mimeDir = new Mimedir();
+        $mimeDir->setCharSet('foobar');
+
+    }
+
+    /**
+     * @expectedException \Sabre\VObject\ParseException
+     */
+    function testDecodeUnsupportedInlineCharset() {
+
+        $vcard = <<<VCF
+BEGIN:VCARD
+VERSION:3.0
+FN;CHARSET=foobar:nothing
+END:VCARD\n
+VCF;
+
+        $mimeDir = new Mimedir();
+        $mimeDir->parse($vcard);
+
+    }
 }


### PR DESCRIPTION
This PR allows a user to specify before encoding that the (vcard/icalendar) input data is not in UTF-8, so the parser can automatically decode it.

It also adds support for the `ENCODING` parameter in vCard 2.1.

Fixes #41 
Closes #43 
