### PR TITLE
VCalendar: Fix timezones stripping

### DIFF
--- a/lib/Component/VCalendar.php
+++ b/lib/Component/VCalendar.php
@@ -299,7 +299,7 @@ class VCalendar extends VObject\Document {
             $timeZone = new DateTimeZone('UTC');
         }
 
-        $stripTimezones = function(Component $component) use ($timeZone) {
+        $stripTimezones = function(Component $component) use ($timeZone, &$stripTimezones) {
 
             foreach ($component->children() as $componentChild) {
                 if ($componentChild instanceof Property\ICalendar\DateTime && $componentChild->hasTime()) {


### PR DESCRIPTION
Fix https://github.com/fruux/sabre-vobject/issues/278.

The issue is that the `stripTimezones` closure is recursive but the
“self” is not defined. This way it works.

Minimal Working Example:

    $a = function ($i) use (&$a) {
        var_dump($i);

        if ($i < 10) {
            $a($i + 1);
        }
    };

Here we can re-use “self” (`$a`) inside the closure because it is closed
into the same lexical scope thanks to `use (&$a)`.