### PR TITLE
Trim whitespaces from the value of the property, except the description

### DIFF
--- a/lib/Property.php
+++ b/lib/Property.php
@@ -93,6 +93,18 @@ abstract class Property extends Node {
      */
     function setValue($value) {
 
+        if ($this->name != 'DESCRIPTION') {
+            if (is_string($value)) {
+                $value = trim($value, ' ');
+            }
+            if (is_array($value)) {
+                foreach ($value as $key => $val) {
+                    if (is_string($val)) {
+                        $value[$key] = trim($val, ' ');
+                    }
+                }
+            }
+        }
         $this->value = $value;
 
     }

--- a/tests/VObject/PropertyTest.php
+++ b/tests/VObject/PropertyTest.php
@@ -48,6 +48,31 @@ class PropertyTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testSetValueWithWhiteSpaces() {
+
+        $cal = new VCalendar();
+
+        $property = $cal->createProperty('propname', 'propvalue');
+        $property->setValue(' value2 ');
+
+        $this->assertEquals('PROPNAME', $property->name);
+        $this->assertEquals('value2', $property->__toString());
+
+    }
+
+    function testSetArrayValueWithWhiteSpaces() {
+
+        $cal = new VCalendar();
+
+        $property = $cal->createProperty('propname', 'propvalue');
+        $property->setValue(array('value2 '));
+
+        $this->assertEquals('PROPNAME', $property->name);
+        $this->assertEquals('value2', $property->__toString());
+
+    }
+
+
     function testParameterExists() {
 
         $cal = new VCalendar();


### PR DESCRIPTION
Ical content from some event providers do contain white spaces after some properties like the DTSTAMP field. This is not valid ical content, but can be easily solved by trimming white spaces from the value of the property. It makes VObject more robust.