### PR TITLE
fix infinite iteration when rrule YEARLY and BYMONTH empty AND fix fatal error when DSTART is not set

### DIFF
--- a/lib/Component/VEvent.php
+++ b/lib/Component/VEvent.php
@@ -58,6 +58,9 @@ class VEvent extends VObject\Component {
 
         }
 
+        if (!isset($this->DTSTART)) {
+            return false;
+        }
         $effectiveStart = $this->DTSTART->getDateTime($start->getTimezone());
         if (isset($this->DTEND)) {
 

--- a/lib/Recur/RRuleIterator.php
+++ b/lib/Recur/RRuleIterator.php
@@ -717,7 +717,9 @@ class RRuleIterator implements Iterator {
                     break;
 
                 case 'BYMONTH' :
-                    $this->byMonth = (array)$value;
+                    if (!empty($value)) {
+                        $this->byMonth = (array)$value;
+                    }
                     break;
 
                 case 'BYSETPOS' :


### PR DESCRIPTION
Lets not have infinite iteration when you have this kind of rule : 
"RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH="

Indeed, when we have a rrule yearly with a parameter bymonth empty, the function nextYearly() iterate infinitely like we can see here (line 605) :

do {
$currentMonth++;
if ($currentMonth > 12) {
$currentYear += $this->interval;
$currentMonth = 1;
}
} while (!in_array($currentMonth, $this->byMonth));





