### PR TITLE
Throw InvalidDataException if DateTimeImmutable constructor fails

### DIFF
--- a/lib/DateTimeParser.php
+++ b/lib/DateTimeParser.php
@@ -43,7 +43,12 @@ class DateTimeParser {
         if ($matches[7] === 'Z' || is_null($tz)) {
             $tz = new DateTimeZone('UTC');
         }
-        $date = new DateTimeImmutable($matches[1] . '-' . $matches[2] . '-' . $matches[3] . ' ' . $matches[4] . ':' . $matches[5] . ':' . $matches[6], $tz);
+
+        try {
+            $date = new DateTimeImmutable($matches[1] . '-' . $matches[2] . '-' . $matches[3] . ' ' . $matches[4] . ':' . $matches[5] . ':' . $matches[6], $tz);
+        } catch (\Exception $e) {
+            throw new InvalidDataException('The supplied iCalendar datetime value is incorrect: ' . $dt);
+        }
 
         return $date;
 
@@ -70,7 +75,11 @@ class DateTimeParser {
             $tz = new DateTimeZone('UTC');
         }
 
-        $date = new DateTimeImmutable($matches[1] . '-' . $matches[2] . '-' . $matches[3], $tz);
+        try {
+            $date = new DateTimeImmutable($matches[1] . '-' . $matches[2] . '-' . $matches[3], $tz);
+        } catch (\Exception $e) {
+            throw new InvalidDataException('The supplied iCalendar date value is incorrect: ' . $date);
+        }
 
         return $date;
 

--- a/tests/VObject/DateTimeParserTest.php
+++ b/tests/VObject/DateTimeParserTest.php
@@ -63,6 +63,16 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @depends testParseICalendarDateTime
+     * @expectedException \Sabre\VObject\InvalidDataException
+     */
+    function testParseICalendarDateTimeInvalidTime() {
+
+        $dateTime = DateTimeParser::parseDateTime('20100316T251405');
+
+    }
+
+    /**
+     * @depends testParseICalendarDateTime
      */
     function testParseICalendarDateTimeUTC() {
 
@@ -149,6 +159,16 @@ class DateTimeParserTest extends \PHPUnit_Framework_TestCase {
     function testParseICalendarDateBadFormat() {
 
         $dateTime = DateTimeParser::parseDate('20100316T141405');
+
+    }
+
+    /**
+     * @depends testParseICalendarDate
+     * @expectedException \Sabre\VObject\InvalidDataException
+     */
+    function testParseICalendarDateInvalidDate() {
+
+        $dateTime = DateTimeParser::parseDate('20101331');
 
     }
 


### PR DESCRIPTION
DateTimeParser fails for syntactically correct, but invalid datetimes with a generic PHP exception instead of InvalidDataException.

This e.g. causes sabre-dav's CalDAV plugin to fail with 500 Internal Server error for such datetimes, instead of rejecting the erroneous iCalendar payload.

For example, a datetime in the 25th hour of the day passes the regex validation but fails with \Exception

    DateTimeImmutable::__construct(): Failed to parse time string (2010-03-16 25:14:05) at position 11

Similarly, a date in the 13th month fails with

    DateTimeImmutable::__construct(): Failed to parse time string (2010-13-31) at position 6

This change fixes both and adds unit tests.