### PR TITLE
Fix #330: Fixed case when overridden recurring events have same start date.

### DIFF
--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -328,7 +328,7 @@ class EventIterator implements \Iterator {
         $index = array();
         foreach($this->overriddenEvents as $key=>$event) {
             $stamp = $event->DTSTART->getDateTime($this->timeZone)->getTimeStamp();
-            $index[$stamp] = $key;
+            $index[$stamp][] = $key;
         }
         krsort($index);
         $this->counter = 0;
@@ -375,8 +375,9 @@ class EventIterator implements \Iterator {
         // overridden event may cut ahead.
         if ($this->overriddenEventsIndex) {
 
-            $offset = end($this->overriddenEventsIndex);
+            $offsets = end($this->overriddenEventsIndex);
             $timestamp = key($this->overriddenEventsIndex);
+            $offset = end($offsets);
             if (!$nextDate || $timestamp < $nextDate->getTimeStamp()) {
                 // Overridden event comes first.
                 $this->currentOverriddenEvent = $this->overriddenEvents[$offset];
@@ -386,7 +387,10 @@ class EventIterator implements \Iterator {
                 $this->currentDate = $this->currentOverriddenEvent->DTSTART->getDateTime($this->timeZone);
 
                 // Ensuring that this item will only be used once.
-                array_pop($this->overriddenEventsIndex);
+                array_pop($this->overriddenEventsIndex[$timestamp]);
+                if (!$this->overriddenEventsIndex[$timestamp]) {
+                    array_pop($this->overriddenEventsIndex);
+                }
 
                 // Exit point!
                 return;
@@ -454,7 +458,7 @@ class EventIterator implements \Iterator {
     /**
      * Overridden event index.
      *
-     * Key is timestamp, value is the index of the item in the $overriddenEvent
+     * Key is timestamp, value is the list of indexes of the item in the $overriddenEvent
      * property.
      *
      * @var array

--- a/tests/VObject/Recur/EventIterator/SameDateForRecurringEventsTest.php
+++ b/tests/VObject/Recur/EventIterator/SameDateForRecurringEventsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sabre\VObject\Recur;
+
+use Sabre\VObject\Recur\EventIterator;
+use Sabre\VObject\Reader;
+
+/**
+ * Testing case when overridden recurring events have same start date.
+ *
+ * Class SameDateForRecurringEventsTest
+ */
+class SameDateForRecurringEventsTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Checking is all events iterated by EventIterator.
+     */
+    public function testAllEventsArePresentInIterator()
+    {
+        $ics = <<<ICS
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:1
+DTSTART;TZID=Europe/Kiev:20160713T110000
+DTEND;TZID=Europe/Kiev:20160713T113000
+RRULE:FREQ=DAILY;INTERVAL=1;COUNT=3
+END:VEVENT
+BEGIN:VEVENT
+UID:2
+DTSTART;TZID=Europe/Kiev:20160713T110000
+DTEND;TZID=Europe/Kiev:20160713T113000
+RECURRENCE-ID;TZID=Europe/Kiev:20160714T110000
+END:VEVENT
+BEGIN:VEVENT
+UID:3
+DTSTART;TZID=Europe/Kiev:20160713T110000
+DTEND;TZID=Europe/Kiev:20160713T113000
+RECURRENCE-ID;TZID=Europe/Kiev:20160715T110000
+END:VEVENT
+BEGIN:VEVENT
+UID:4
+DTSTART;TZID=Europe/Kiev:20160713T110000
+DTEND;TZID=Europe/Kiev:20160713T113000
+RECURRENCE-ID;TZID=Europe/Kiev:20160716T110000
+END:VEVENT
+END:VCALENDAR
+
+
+ICS;
+        $vCalendar = Reader::read($ics);
+        $eventIterator = new EventIterator($vCalendar->getComponents());
+
+        $this->assertEquals(4, iterator_count($eventIterator), 'in ICS 4 events');
+    }
+}


### PR DESCRIPTION
If ```Sabre\VObject\Recur\EventIterator``` takes on input list os recurring events with same date start. In ```EventIterator::rewind``` generate overridden events index by timestamp of date start(```EventIterator::$overriddenEventsIndex```). So index offset will be rewritten by last event with same date start. 
Fix issue: #331 