### PR TITLE
fixed copyright info in timezone generator

### DIFF
--- a/bin/fetch_windows_zones.php
+++ b/bin/fetch_windows_zones.php
@@ -36,7 +36,7 @@ fwrite($f, " *\n");
 fwrite($f, " * Last update: " . date(DATE_W3C) . "\n");
 fwrite($f, " * Source: " . $windowsZonesUrl . "\n");
 fwrite($f, " *\n");
-fwrite($f, " * @copyright Copyright (C) 2011-2015 fruux GmbH (https://fruux.com/).\n");
+fwrite($f, " * @copyright Copyright (C) fruux GmbH (https://fruux.com/).\n");
 fwrite($f, " * @license http://sabre.io/license/ Modified BSD License\n");
 fwrite($f, " */\n");
 fwrite($f, "\n");


### PR DESCRIPTION
justed noticed because https://github.com/fruux/sabre-vobject/commit/b03193a7d32d18b2b56a1a1c222906ea58c8e016 contains a "oudated" copyright year in the generated file.