### PR TITLE
ISSUE 351 - fix EventIteratorFastForward

### DIFF
--- a/lib/Recur/EventIterator.php
+++ b/lib/Recur/EventIterator.php
@@ -409,7 +409,7 @@ class EventIterator implements \Iterator {
      */
     function fastForward(DateTimeInterface $dateTime) {
 
-        while ($this->valid() && $this->getDtEnd() < $dateTime) {
+        while ($this->valid() && $this->getDtEnd() <= $dateTime) {
             $this->next();
         }
 

--- a/tests/VObject/Component/VEventTest.php
+++ b/tests/VObject/Component/VEventTest.php
@@ -81,6 +81,13 @@ class VEventTest extends \PHPUnit_Framework_TestCase {
         $vevent8->add('EXDATE', '20130329T140000');
         $tests[] = [$vevent8, new \DateTime('2013-03-01'), new \DateTime('2013-04-01'), false];
 
+        // Added this test to check recurring all day event that repeat every day
+        $vevent9 = clone $vevent;
+        $vevent9->DTSTART = '20161027';
+        $vevent9->DTEND = '20161028';
+        $vevent9->RRULE = 'FREQ=DAILY';
+        $tests[] = [$vevent9, new \DateTime('2016-10-31'), new \DateTime('2016-12-12'), true];
+
         return $tests;
 
     }

--- a/tests/VObject/Recur/EventIterator/MainTest.php
+++ b/tests/VObject/Recur/EventIterator/MainTest.php
@@ -1120,6 +1120,33 @@ class MainTest extends \PHPUnit_Framework_TestCase {
     /**
      * @depends testValues
      */
+    function testFastForwardAllDayEventThatStopAtTheStartTime() {
+        $vcal = new VCalendar();
+        $ev = $vcal->createComponent('VEVENT');
+
+        $ev->UID = 'bla';
+        $ev->RRULE = 'FREQ=DAILY';
+
+        $dtStart = $vcal->createProperty('DTSTART');
+        $dtStart->setDateTime(new DateTimeImmutable('2011-04-04', new DateTimeZone('UTC')));
+        $ev->add($dtStart);
+
+        $dtEnd = $vcal->createProperty('DTSTART');
+        $dtEnd->setDateTime(new DateTimeImmutable('2011-04-05', new DateTimeZone('UTC')));
+        $ev->add($dtEnd);
+
+        $vcal->add($ev);
+
+        $it = new EventIterator($vcal, (string)$ev->UID);
+
+        $it->fastForward(new DateTimeImmutable('2011-04-05T000000', new DateTimeZone('UTC')));
+
+        $this->assertEquals(new DateTimeImmutable('2011-04-06'), $it->getDTStart());
+    }
+
+    /**
+     * @depends testValues
+     */
     function testComplexExclusions() {
 
         $vcal = new VCalendar();


### PR DESCRIPTION
Before this fix, when called with a recurring allDay event and a datetime at
midnight this method returned the instance that finish just before the
given datetime if this instance has this datetime for end.
