### PR TITLE
dont disable xdebug manually anymore in travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
   - ./bin/sabre-cs-fixer fix . --dry-run --diff
 
 before_script:
-  - phpenv config-rm xdebug.ini; true
   - composer install
 
 cache:


### PR DESCRIPTION
travis updates composer within the build to 1.3.x which contains a native workaround for xdebug problems.