### PR TITLE
For a vtodo, a start alarm must refer to dtstart

### DIFF
--- a/lib/Component/VAlarm.php
+++ b/lib/Component/VAlarm.php
@@ -34,14 +34,7 @@ class VAlarm extends VObject\Component {
 
             $parentComponent = $this->parent;
             if ($related === 'START') {
-
-                if ($parentComponent->name === 'VTODO') {
-                    $propName = 'DUE';
-                } else {
-                    $propName = 'DTSTART';
-                }
-
-                $effectiveTrigger = $parentComponent->$propName->getDateTime();
+                $effectiveTrigger = $parentComponent->DTSTART->getDateTime();
                 $effectiveTrigger = $effectiveTrigger->add($triggerDuration);
             } else {
                 if ($parentComponent->name === 'VTODO') {


### PR DESCRIPTION
Hi,
Like the RFC 5545 (https://tools.ietf.org/html/rfc5545#page-74) said:
"In an alarm set to trigger on the "START" of an event or to-do,
      the "DTSTART" property MUST be present in the associated event or
      to-do."
So when related = start, we must use the dtstart of the vtodo, not the due. Since it's the same thing as the vevent, the if isn't needed.