### PR TITLE
Pin PHPUnit version to avoid breaking unit tests for PHP 7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
         "sabre/xml"    : ">=1.5 <3.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "*",
-        "sabre/cs"        : "^1.0.0"
+        "sabre/cs"        : "^1.0.0",
+        "phpunit/phpunit": "^4.8"
 
     },
     "suggest" : {


### PR DESCRIPTION
Because PHPUnit recently released a v6 with very important breaking changes, it is required to specify a version to not break our tests. Typically this will solve broken tests as seen in #371.

Also see [this excellent explanation](https://yarnpkg.com/blog/2016/11/24/lockfiles-for-all/) as to why composer.lock should be committed.