### PR TITLE
Add Pacific Time (US & Canada) as exchange timezone

### DIFF
--- a/lib/timezonedata/exchangezones.php
+++ b/lib/timezonedata/exchangezones.php
@@ -85,6 +85,7 @@ return [
     'Saskatchewan'                                             => 'America/Edmonton',
     'Arizona'                                                  => 'America/Phoenix',
     'Mountain Time (US & Canada)'                              => 'America/Denver', // Best guess
+    'Pacific Time (US & Canada)'                               => 'America/Los_Angeles', // Best guess
     'Pacific Time (US & Canada); Tijuana'                      => 'America/Los_Angeles', // Best guess
     'Alaska'                                                   => 'America/Anchorage',
     'Hawaii'                                                   => 'Pacific/Honolulu',


### PR DESCRIPTION
As the tilt says, it adds _Pacific Time (US & Canada)_ as exchange timezone.